### PR TITLE
fix(binar): row_stacked and Hash now respect row pointer reordering

### DIFF
--- a/binar/src/matrix/aligned_bitmatrix.rs
+++ b/binar/src/matrix/aligned_bitmatrix.rs
@@ -144,7 +144,15 @@ pub struct AlignedBitMatrix {
 
 impl Hash for AlignedBitMatrix {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.blocks.hash(state);
+        // Hash rows in logical order (through row pointers) so that
+        // matrices with swapped/permuted rows hash correctly.
+        self.column_count.hash(state);
+        for r in 0..self.row_count() {
+            let rowstride = Self::rowstride_of(self.column_count);
+            let row_ptr = self.rows[r];
+            let row_blocks = unsafe { std::slice::from_raw_parts(row_ptr, rowstride) };
+            row_blocks.hash(state);
+        }
     }
 }
 
@@ -1061,7 +1069,14 @@ where
     let mut row_count = 0;
     for matrix in matrices {
         debug_assert!(column_count.is_none() || column_count.unwrap() == matrix.column_count());
-        buffer.append(&mut matrix.blocks.clone());
+        let rowstride = AlignedBitMatrix::rowstride_of(matrix.column_count());
+        // Copy rows in logical order (through row pointers) rather than
+        // physical block order, so that swap_rows/permute_rows are respected.
+        for r in 0..matrix.row_count() {
+            let row_ptr = matrix.rows[r];
+            let row_blocks = unsafe { std::slice::from_raw_parts(row_ptr, rowstride) };
+            buffer.extend_from_slice(row_blocks);
+        }
         column_count = Some(matrix.column_count());
         row_count += matrix.row_count();
     }

--- a/binar/tests/bitmatrix_test.rs
+++ b/binar/tests/bitmatrix_test.rs
@@ -1,7 +1,7 @@
 use binar::matrix::tiny_matrix::{tiny_matrix_from_bitmatrix, tiny_matrix_rref};
 use binar::matrix::{
     AlignedBitMatrix, AlignedEchelonForm as EchelonForm, complete_to_full_rank_row_basis, directly_summed,
-    kernel_basis_matrix,
+    kernel_basis_matrix, row_stacked,
 };
 use binar::vec::AlignedBitVec;
 use binar::{Bitwise, BitwiseMut, BitwisePairMut};
@@ -743,4 +743,36 @@ fn random_bitvec(size: usize) -> AlignedBitVec {
         bitvec.assign_index(index, rand::rng().random());
     }
     bitvec
+}
+
+#[test]
+fn row_stacked_respects_swap_rows() {
+    // Regression test: row_stacked previously copied the raw blocks buffer
+    // rather than following row pointers, so swap_rows was silently undone.
+    let mut m = AlignedBitMatrix::identity(4);
+    // Swap rows 0 and 3: row 0 should now be [0,0,0,1], row 3 should be [1,0,0,0]
+    m.swap_rows(0, 3);
+    assert!(m.get((0, 3)));
+    assert!(!m.get((0, 0)));
+
+    let stacked = row_stacked([&m]);
+    // The stacked result must reflect the swapped order
+    assert!(stacked.get((0, 3)), "row_stacked did not preserve swap_rows");
+    assert!(!stacked.get((0, 0)), "row_stacked did not preserve swap_rows");
+    assert!(stacked.get((3, 0)));
+    assert!(!stacked.get((3, 3)));
+    assert_eq!(m, stacked);
+}
+
+#[test]
+fn row_stacked_respects_permute_rows() {
+    let mut m = AlignedBitMatrix::identity(3);
+    m.permute_rows(&[2, 0, 1]); // row 0 ← old row 2, row 1 ← old row 0, row 2 ← old row 1
+
+    let stacked = row_stacked([&m]);
+    for r in 0..3 {
+        for c in 0..3 {
+            assert_eq!(stacked.get((r, c)), m.get((r, c)), "mismatch at ({r}, {c})");
+        }
+    }
 }


### PR DESCRIPTION
Fixes #43.

## Problem

`AlignedBitMatrix` stores data in two parts: a contiguous `blocks: Vec<BitBlock>` buffer and a `rows: Vec<*mut BitBlock>` pointer array indexing into it. `swap_rows` and `permute_rows` reorder the pointers without moving the underlying block data.

Two operations read the raw `blocks` buffer directly, bypassing the pointer array:

- **`row_stacked`** called `matrix.blocks.clone()`, copying blocks in physical storage order and constructing fresh sequential pointers — silently undoing any prior `swap_rows`/`permute_rows`.
- **`Hash`** hashed `self.blocks` directly, so logically-equal matrices with different physical row arrangements produced different hashes.

All other operations (`get`, `set`, `row`, `row_words`, M4RI multiplication, `transposed`, `echelonize`) correctly access data through the `rows[i]` pointers and were not affected.

## Fix

- **`row_stacked`**: iterate rows through the `rows[i]` pointers instead of cloning the raw `blocks` buffer.
- **`Hash`**: hash rows in logical (pointer) order instead of hashing `self.blocks`.

## Trade-offs

The fix for `row_stacked` replaces a single `blocks.clone()` (one contiguous memcpy) with N per-row `extend_from_slice` calls that read through pointers. If pointers have been reordered, the source reads may be non-sequential. For matrices that have not been swapped, the pointer sequence is sequential and the access pattern is identical to before.

An alternative approach would be to make `swap_rows` and `permute_rows` physically move the block data instead of just swapping pointers. This would restore the invariant that `blocks` is always in logical order — making `row_stacked`, `Hash`, `as_words`, `as_bytes`, and `clone` all trivially correct. However, `swap_rows` would become O(columns) instead of O(1), and echelonization calls `swap_rows` in its inner loop, so this could impact performance for large matrices.

## Tests

- `row_stacked_respects_swap_rows`: identity matrix with swapped rows, stacked, verified element by element.
- `row_stacked_respects_permute_rows`: identity matrix with permuted rows, stacked, verified element by element.