### PR TITLE
feat(binar): add row_space_intersection; use in paulimer

### DIFF
--- a/binar/bindings/python/binar.pyi
+++ b/binar/bindings/python/binar.pyi
@@ -125,7 +125,7 @@ class BitMatrix:
             Matrix whose rows form a basis for the kernel.
         """
         ...
-    def row_space_intersection(self, other: "BitMatrix") -> "BitMatrix":
+    def row_space_intersection_with(self, other: "BitMatrix") -> "BitMatrix":
         """Compute a basis for the intersection of the row spaces of two matrices.
 
         Given ``V = rowspace(self)`` and ``W = rowspace(other)``, returns a matrix

--- a/binar/bindings/python/binar.pyi
+++ b/binar/bindings/python/binar.pyi
@@ -125,6 +125,20 @@ class BitMatrix:
             Matrix whose rows form a basis for the kernel.
         """
         ...
+    def row_space_intersection(self, other: "BitMatrix") -> "BitMatrix":
+        """Compute a basis for the intersection of the row spaces of two matrices.
+
+        Given ``V = rowspace(self)`` and ``W = rowspace(other)``, returns a matrix
+        whose rows form a basis for ``V ∩ W``.
+
+        Args:
+            other: Matrix with the same number of columns as ``self``.
+
+        Returns:
+            Matrix whose rows span ``V ∩ W``.  Returns a 0-row matrix if the
+            intersection is trivial.
+        """
+        ...
     def __getitem__(self, index: tuple[int, int]) -> bool: ...
     def __setitem__(self, index: tuple[int, int], to: bool) -> None: ...
     def __eq__(self, other: object) -> bool: ...

--- a/binar/bindings/python/src/py_bitmatrix.rs
+++ b/binar/bindings/python/src/py_bitmatrix.rs
@@ -219,6 +219,10 @@ impl PyBitMatrix {
         BitMatrix::kernel(self).into()
     }
 
+    pub fn row_space_intersection(&self, other: &PyBitMatrix) -> PyBitMatrix {
+        BitMatrix::row_space_intersection(self, other).into()
+    }
+
     #[allow(clippy::needless_pass_by_value)]
     pub fn submatrix(&self, rows: Vec<usize>, columns: Vec<usize>) -> PyBitMatrix {
         BitMatrix::submatrix(self, &rows, &columns).into()

--- a/binar/bindings/python/src/py_bitmatrix.rs
+++ b/binar/bindings/python/src/py_bitmatrix.rs
@@ -219,8 +219,8 @@ impl PyBitMatrix {
         BitMatrix::kernel(self).into()
     }
 
-    pub fn row_space_intersection(&self, other: &PyBitMatrix) -> PyBitMatrix {
-        BitMatrix::row_space_intersection(self, other).into()
+    pub fn row_space_intersection_with(&self, other: &PyBitMatrix) -> PyBitMatrix {
+        BitMatrix::row_space_intersection_with(self, other).into()
     }
 
     #[allow(clippy::needless_pass_by_value)]

--- a/binar/src/matrix/aligned_bitmatrix.rs
+++ b/binar/src/matrix/aligned_bitmatrix.rs
@@ -662,6 +662,73 @@ impl AlignedBitMatrix {
     pub fn rank(&self) -> usize {
         self.clone().echelonize().len()
     }
+
+    /// Computes a basis for `V ∩ W` where `V` and `W` are the row spaces of
+    /// `self` (= `A`) and `other` (= `B`) respectively.
+    ///
+    /// A vector `u` lies in `V ∩ W` iff `u = αᵀ A = βᵀ B` for some vectors
+    /// `α ∈ 𝔽₂^{r_A}` and `β ∈ 𝔽₂^{r_B}`, where `r_A` and `r_B` are,
+    /// respectively, the ranks of `A` and `B`.  Adding the previous two
+    /// identities for `u` over `𝔽₂`, gives us `αᵀ A + βᵀ B = 0`, i.e., the
+    /// vector `[αᵀ | βᵀ]` lies in the left kernel (i.e., the kernel of the
+    /// transpose) of
+    ///              ⎡A⎤
+    /// M = [A; B] = ⎢ ⎥.
+    ///              ⎣B⎦
+    ///
+    /// We compute `V ∩ W = π_A(ker(Mᵀ)) A`, where `π_A` is the projection
+    /// onto the first block component:
+    ///   1. Stack `M = [A; B]`, dimensions `(r_A + r_B) × n`.
+    ///   2. Echelonize `M` with transformation `T` (so `T M = RREF(M)`).
+    ///   3. Rows of `T` beyond the rank are a basis for `ker(Mᵀ)`.
+    ///   4. Extract their first `r_A` entries (the α-coefficients).
+    ///   5. Multiply by `A` to obtain vectors in `V ∩ W`.
+    ///   6. Echelonize the result to get a proper basis.
+    ///
+    /// Cost: `𝒪((r_A + r_B)² · n)` when `r_A + r_B ≪ n`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self` and `other` have different column counts.
+    #[must_use]
+    pub fn row_space_intersection(&self, other: &AlignedBitMatrix) -> AlignedBitMatrix {
+        assert_eq!(
+            self.column_count(),
+            other.column_count(),
+            "Matrices must have the same number of columns (same ambient space)"
+        );
+
+        if self.row_count() == 0 || other.row_count() == 0 {
+            return AlignedBitMatrix::zeros(0, self.column_count());
+        }
+
+        // M = [A; B], dimensions (r_A + r_B) × n.
+        let stacked = row_stacked([self, other].into_iter());
+
+        // T M = RREF(M).  Rows rank..total of T are a basis for ker(Mᵀ).
+        let echelon = EchelonForm::new(stacked);
+        let rank = echelon.pivots.len();
+        let total = self.row_count() + other.row_count();
+
+        if rank == total {
+            return AlignedBitMatrix::zeros(0, self.column_count());
+        }
+
+        // Extract the α-parts (first r_A columns) of the dependency rows.
+        let dep_rows: Vec<usize> = (rank..total).collect();
+        let alpha_cols: Vec<usize> = (0..self.row_count()).collect();
+        let alphas = echelon.transform.submatrix(&dep_rows, &alpha_cols);
+
+        // V ∩ W = { αᵀ A : [αᵀ | βᵀ] ∈ ker(Mᵀ) }.
+        // The product may contain linearly dependent rows; echelonize to
+        // obtain a proper basis.
+        let mut result = alphas.dot(self);
+        let pivots = result.echelonize();
+        let basis_rows: Vec<usize> = (0..pivots.len()).collect();
+        let all_cols: Vec<usize> = (0..result.column_count()).collect();
+        result.submatrix(&basis_rows, &all_cols)
+    }
+
     pub fn transposed(&self) -> Self {
         const TILE_SIZE: usize = 64;
         use crate::matrix::transpose_kernel::transpose_64x64_inplace;

--- a/binar/src/matrix/aligned_bitmatrix.rs
+++ b/binar/src/matrix/aligned_bitmatrix.rs
@@ -690,7 +690,6 @@ impl AlignedBitMatrix {
     /// # Panics
     ///
     /// Panics if `self` and `other` have different column counts.
-    #[must_use]
     pub fn row_space_intersection(&self, other: &AlignedBitMatrix) -> AlignedBitMatrix {
         assert_eq!(
             self.column_count(),
@@ -703,7 +702,7 @@ impl AlignedBitMatrix {
         }
 
         // M = [A; B], dimensions (r_A + r_B) × n.
-        let stacked = row_stacked([self, other].into_iter());
+        let stacked = row_stacked([self, other]);
 
         // T M = RREF(M).  Rows rank..total of T are a basis for ker(Mᵀ).
         let echelon = EchelonForm::new(stacked);

--- a/binar/src/matrix/aligned_bitmatrix.rs
+++ b/binar/src/matrix/aligned_bitmatrix.rs
@@ -690,7 +690,7 @@ impl AlignedBitMatrix {
     /// # Panics
     ///
     /// Panics if `self` and `other` have different column counts.
-    pub fn row_space_intersection(&self, other: &AlignedBitMatrix) -> AlignedBitMatrix {
+    pub fn row_space_intersection_with(&self, other: &AlignedBitMatrix) -> AlignedBitMatrix {
         assert_eq!(
             self.column_count(),
             other.column_count(),

--- a/binar/src/matrix/bitmatrix.rs
+++ b/binar/src/matrix/bitmatrix.rs
@@ -863,11 +863,11 @@ impl BitMatrix {
     /// Computes a basis for V ∩ W where V and W are the row spaces of
     /// `self` and `other` respectively.
     ///
-    /// See [`AlignedBitMatrix::row_space_intersection`] for the algorithm
+    /// See [`AlignedBitMatrix::row_space_intersection_with`] for the algorithm
     /// (single echelonization of [A; B] plus one matrix product).
-    pub fn row_space_intersection(&self, other: &BitMatrix) -> BitMatrix {
+    pub fn row_space_intersection_with(&self, other: &BitMatrix) -> BitMatrix {
         BitMatrix {
-            aligned: self.aligned.row_space_intersection(&other.aligned),
+            aligned: self.aligned.row_space_intersection_with(&other.aligned),
         }
     }
 }

--- a/binar/src/matrix/bitmatrix.rs
+++ b/binar/src/matrix/bitmatrix.rs
@@ -859,6 +859,18 @@ impl BitMatrix {
         let aligned = aligned_kernel(&self.aligned);
         BitMatrix::from_aligned(aligned)
     }
+
+    /// Computes a basis for V ∩ W where V and W are the row spaces of
+    /// `self` and `other` respectively.
+    ///
+    /// See [`AlignedBitMatrix::row_space_intersection`] for the algorithm
+    /// (single echelonization of [A; B] plus one matrix product).
+    #[must_use]
+    pub fn row_space_intersection(&self, other: &BitMatrix) -> BitMatrix {
+        BitMatrix {
+            aligned: self.aligned.row_space_intersection(&other.aligned),
+        }
+    }
 }
 
 unsafe impl Send for BitMatrix {}

--- a/binar/src/matrix/bitmatrix.rs
+++ b/binar/src/matrix/bitmatrix.rs
@@ -865,7 +865,6 @@ impl BitMatrix {
     ///
     /// See [`AlignedBitMatrix::row_space_intersection`] for the algorithm
     /// (single echelonization of [A; B] plus one matrix product).
-    #[must_use]
     pub fn row_space_intersection(&self, other: &BitMatrix) -> BitMatrix {
         BitMatrix {
             aligned: self.aligned.row_space_intersection(&other.aligned),

--- a/binar/tests/bitmatrix_test.rs
+++ b/binar/tests/bitmatrix_test.rs
@@ -747,16 +747,12 @@ fn random_bitvec(size: usize) -> AlignedBitVec {
 
 #[test]
 fn row_stacked_respects_swap_rows() {
-    // Regression test: row_stacked previously copied the raw blocks buffer
-    // rather than following row pointers, so swap_rows was silently undone.
     let mut m = AlignedBitMatrix::identity(4);
-    // Swap rows 0 and 3: row 0 should now be [0,0,0,1], row 3 should be [1,0,0,0]
     m.swap_rows(0, 3);
     assert!(m.get((0, 3)));
     assert!(!m.get((0, 0)));
 
     let stacked = row_stacked([&m]);
-    // The stacked result must reflect the swapped order
     assert!(stacked.get((0, 3)), "row_stacked did not preserve swap_rows");
     assert!(!stacked.get((0, 0)), "row_stacked did not preserve swap_rows");
     assert!(stacked.get((3, 0)));
@@ -767,12 +763,54 @@ fn row_stacked_respects_swap_rows() {
 #[test]
 fn row_stacked_respects_permute_rows() {
     let mut m = AlignedBitMatrix::identity(3);
-    m.permute_rows(&[2, 0, 1]); // row 0 ← old row 2, row 1 ← old row 0, row 2 ← old row 1
+    m.permute_rows(&[2, 0, 1]);
 
     let stacked = row_stacked([&m]);
     for r in 0..3 {
         for c in 0..3 {
             assert_eq!(stacked.get((r, c)), m.get((r, c)), "mismatch at ({r}, {c})");
         }
+    }
+}
+
+#[test]
+fn row_space_intersection_identity() {
+    use binar::BitMatrix;
+    let id = BitMatrix::identity(5);
+    let result = id.row_space_intersection(&id);
+    assert_eq!(result.rank(), 5);
+}
+
+#[test]
+fn row_space_intersection_with_zero() {
+    use binar::BitMatrix;
+    let m = BitMatrix::identity(5);
+    let zero = BitMatrix::zeros(0, 5);
+    let result = m.row_space_intersection(&zero);
+    assert_eq!(result.rank(), 0);
+}
+
+proptest! {
+    #[test]
+    fn row_space_intersection_idempotent(matrix in arbitrary_bitmatrix(30)) {
+        let result = matrix.row_space_intersection(&matrix);
+        assert_eq!(result.rank(), matrix.rank());
+    }
+
+    #[test]
+    fn row_space_intersection_commutative(
+        left in arbitrary_bitmatrix(20),
+    ) {
+        let right_rows = left.row_count().min(10);
+        if right_rows == 0 || left.column_count() == 0 {
+            return Ok(());
+        }
+        let right = left.submatrix(
+            &(0..right_rows).collect::<Vec<_>>(),
+            &(0..left.column_count()).collect::<Vec<_>>()
+        );
+        let lr = left.row_space_intersection(&right);
+        let rl = right.row_space_intersection(&left);
+        prop_assert_eq!(lr.rank(), rl.rank());
     }
 }

--- a/binar/tests/bitmatrix_test.rs
+++ b/binar/tests/bitmatrix_test.rs
@@ -774,31 +774,31 @@ fn row_stacked_respects_permute_rows() {
 }
 
 #[test]
-fn row_space_intersection_identity() {
+fn row_space_intersection_with_identity() {
     use binar::BitMatrix;
     let id = BitMatrix::identity(5);
-    let result = id.row_space_intersection(&id);
+    let result = id.row_space_intersection_with(&id);
     assert_eq!(result.rank(), 5);
 }
 
 #[test]
-fn row_space_intersection_with_zero() {
+fn row_space_intersection_with_with_zero() {
     use binar::BitMatrix;
     let m = BitMatrix::identity(5);
     let zero = BitMatrix::zeros(0, 5);
-    let result = m.row_space_intersection(&zero);
+    let result = m.row_space_intersection_with(&zero);
     assert_eq!(result.rank(), 0);
 }
 
 proptest! {
     #[test]
-    fn row_space_intersection_idempotent(matrix in arbitrary_bitmatrix(30)) {
-        let result = matrix.row_space_intersection(&matrix);
+    fn row_space_intersection_with_idempotent(matrix in arbitrary_bitmatrix(30)) {
+        let result = matrix.row_space_intersection_with(&matrix);
         assert_eq!(result.rank(), matrix.rank());
     }
 
     #[test]
-    fn row_space_intersection_commutative(
+    fn row_space_intersection_with_commutative(
         left in arbitrary_bitmatrix(20),
     ) {
         let right_rows = left.row_count().min(10);
@@ -809,8 +809,8 @@ proptest! {
             &(0..right_rows).collect::<Vec<_>>(),
             &(0..left.column_count()).collect::<Vec<_>>()
         );
-        let lr = left.row_space_intersection(&right);
-        let rl = right.row_space_intersection(&left);
+        let lr = left.row_space_intersection_with(&right);
+        let rl = right.row_space_intersection_with(&left);
         prop_assert_eq!(lr.rank(), rl.rank());
     }
 }

--- a/paulimer/src/pauli_group.rs
+++ b/paulimer/src/pauli_group.rs
@@ -595,7 +595,7 @@ fn phase_insensitive_intersection_of(group_a: &PauliGroup, group_b: &PauliGroup)
     let bits1 = as_bitmatrix(group_a.standard_generators(), support);
     let bits2 = as_bitmatrix(group_b.standard_generators(), support);
 
-    let intersection_matrix = bits1.row_space_intersection(&bits2);
+    let intersection_matrix = bits1.row_space_intersection_with(&bits2);
 
     let generators = as_sparse_paulis(&intersection_matrix, support);
     PauliGroup::new(&generators)

--- a/paulimer/src/pauli_group.rs
+++ b/paulimer/src/pauli_group.rs
@@ -595,9 +595,7 @@ fn phase_insensitive_intersection_of(group_a: &PauliGroup, group_b: &PauliGroup)
     let bits1 = as_bitmatrix(group_a.standard_generators(), support);
     let bits2 = as_bitmatrix(group_b.standard_generators(), support);
 
-    let nullspace1 = kernel_basis_matrix(&bits1);
-    let nullspace2 = kernel_basis_matrix(&bits2);
-    let intersection_matrix = kernel_basis_matrix(&row_stacked(&[nullspace1, nullspace2]));
+    let intersection_matrix = bits1.row_space_intersection(&bits2);
 
     let generators = as_sparse_paulis(&intersection_matrix, support);
     PauliGroup::new(&generators)


### PR DESCRIPTION
Depends on #44.

## Summary

Add `BitMatrix::row_space_intersection` to binar and use it to simplify
`phase_insensitive_intersection_of` in paulimer.

## Motivation

Computing the intersection of two row spaces over GF(2) is a recurring
operation — paulimer's `phase_insensitive_intersection_of` uses it for
Pauli group intersection, and errata's `intersection_matrix_of` uses it
for essential check computation.

The prior pattern required three separate kernel computations:

```rust
let nullspace1 = kernel_basis_matrix(&bits1);
let nullspace2 = kernel_basis_matrix(&bits2);
let result = kernel_basis_matrix(&row_stacked(&[nullspace1, nullspace2]));
```

The third kernel operates on a matrix with up to `2n` rows (where `n` is
the ambient dimension), making the cost O(n³) even when the input
subspaces have low rank.

## Approach

A vector `u` lies in `V ∩ W` iff `u = αᵀ A = βᵀ B` for some vectors
`α ∈ 𝔽₂^{r_A}` and `β ∈ 𝔽₂^{r_B}`. Adding these two identities over
`𝔽₂` gives `αᵀ A + βᵀ B = 0`, i.e., the vector `[αᵀ | βᵀ]` lies in
the left kernel of `M = [A; B]`.

We compute `V ∩ W = π_A(ker(Mᵀ)) A`:
1. Stack `M = [A; B]`, dimensions `(r_A + r_B) × n`.
2. Echelonize `M` with transformation `T` (so `T M = RREF(M)`).
3. Rows of `T` beyond the rank are a basis for `ker(Mᵀ)`.
4. Extract their first `r_A` entries (the α-coefficients).
5. Multiply by `A` to obtain vectors in `V ∩ W`.
6. Echelonize the result to get a proper basis.

Cost: `O((r_A + r_B)² · n)` when `r_A + r_B ≪ n` — a single
echelonization of the stacked matrix plus one matrix product, vs three
echelonizations where the largest operates on a ~2n-row matrix.

## Changes

- **binar**: `row_space_intersection` on `AlignedBitMatrix` and `BitMatrix`
- **binar Python bindings**: PyO3 wrapper + `.pyi` stub
- **paulimer**: `phase_insensitive_intersection_of` simplified to one call

## Testing

- Deterministic: identity ∩ identity, V ∩ {0}
- Proptest: idempotency (V ∩ V has same rank as V)
- Proptest: commutativity (rank(V ∩ W) = rank(W ∩ V))
- All existing paulimer tests pass (16 passed, 1 ignored)
- `cargo clippy-all` clean