### PR TITLE
feat(binar): add sparse ↔ dense BitMatrix conversion

### DIFF
--- a/binar/Cargo.toml
+++ b/binar/Cargo.toml
@@ -24,7 +24,7 @@ python = ["dep:pyo3"]
 rand = "0.10"
 sorted-vec = "0.8"
 sorted-iter = "0.1"
-derive_more = { version = "2.0.1", features = ["deref", "deref_mut", "from", "into"] }
+derive_more = { version = "2.0.1", features = ["deref", "deref_mut", "display", "error", "from", "into"] }
 pyo3 = { version = "0.27.1", optional = true }
 
 [dev-dependencies]

--- a/binar/bindings/python/binar.pyi
+++ b/binar/bindings/python/binar.pyi
@@ -44,6 +44,30 @@ class BitMatrix:
         """Create a matrix filled with ones."""
         ...
     @staticmethod
+    def from_sparse_columns(columns: list[list[int]], row_count: int) -> "BitMatrix":
+        """Construct a matrix from sparse column descriptions.
+
+        Args:
+            columns: Each element is a list of row indices where the bit is 1.
+            row_count: Total number of rows.
+        """
+        ...
+    @staticmethod
+    def from_sparse_rows(rows: list[list[int]], column_count: int) -> "BitMatrix":
+        """Construct a matrix from sparse row descriptions.
+
+        Args:
+            rows: Each element is a list of column indices where the bit is 1.
+            column_count: Total number of columns.
+        """
+        ...
+    def sparse_columns(self) -> list[list[int]]:
+        """Return each column as a sorted list of row indices where the bit is 1."""
+        ...
+    def sparse_rows(self) -> list[list[int]]:
+        """Return each row as a sorted list of column indices where the bit is 1."""
+        ...
+    @staticmethod
     def _from_bytes(_rows: int, columns: int, data: bytes) -> "BitMatrix": ...
     @property
     def row_count(self) -> int:

--- a/binar/bindings/python/binar.pyi
+++ b/binar/bindings/python/binar.pyi
@@ -44,21 +44,31 @@ class BitMatrix:
         """Create a matrix filled with ones."""
         ...
     @staticmethod
-    def from_sparse_columns(columns: list[list[int]], row_count: int) -> "BitMatrix":
+    def from_sparse_columns(columns: list[list[int]], row_count: int, column_count: int) -> "BitMatrix":
         """Construct a matrix from sparse column descriptions.
 
         Args:
             columns: Each element is a list of row indices where the bit is 1.
             row_count: Total number of rows.
+            column_count: Total number of columns.
+
+        Raises:
+            ValueError: If more columns are provided than column_count,
+                or if any row index is out of bounds.
         """
         ...
     @staticmethod
-    def from_sparse_rows(rows: list[list[int]], column_count: int) -> "BitMatrix":
+    def from_sparse_rows(rows: list[list[int]], row_count: int, column_count: int) -> "BitMatrix":
         """Construct a matrix from sparse row descriptions.
 
         Args:
             rows: Each element is a list of column indices where the bit is 1.
+            row_count: Total number of rows.
             column_count: Total number of columns.
+
+        Raises:
+            ValueError: If more rows are provided than row_count,
+                or if any column index is out of bounds.
         """
         ...
     def sparse_columns(self) -> list[list[int]]:

--- a/binar/bindings/python/binar.pyi
+++ b/binar/bindings/python/binar.pyi
@@ -44,6 +44,40 @@ class BitMatrix:
         """Create a matrix filled with ones."""
         ...
     @staticmethod
+    def from_sparse_columns(columns: Iterable[Iterable[int]], row_count: int, column_count: int) -> "BitMatrix":
+        """Construct a matrix from sparse column descriptions.
+
+        Args:
+            columns: Each element is an iterable of row indices where the bit is 1.
+            row_count: Total number of rows.
+            column_count: Total number of columns.
+
+        Raises:
+            ValueError: If more columns are provided than column_count,
+                or if any row index is out of bounds.
+        """
+        ...
+    @staticmethod
+    def from_sparse_rows(rows: Iterable[Iterable[int]], row_count: int, column_count: int) -> "BitMatrix":
+        """Construct a matrix from sparse row descriptions.
+
+        Args:
+            rows: Each element is an iterable of column indices where the bit is 1.
+            row_count: Total number of rows.
+            column_count: Total number of columns.
+
+        Raises:
+            ValueError: If more rows are provided than row_count,
+                or if any column index is out of bounds.
+        """
+        ...
+    def sparse_columns(self) -> list[list[int]]:
+        """Return each column as a sorted list of row indices where the bit is 1."""
+        ...
+    def sparse_rows(self) -> list[list[int]]:
+        """Return each row as a sorted list of column indices where the bit is 1."""
+        ...
+    @staticmethod
     def _from_bytes(_rows: int, columns: int, data: bytes) -> "BitMatrix": ...
     @property
     def row_count(self) -> int:

--- a/binar/bindings/python/src/py_bitmatrix.rs
+++ b/binar/bindings/python/src/py_bitmatrix.rs
@@ -1,6 +1,6 @@
 use crate::py_bitvec::PyBitVec;
 use binar::{
-    BitMatrix, BitVec,
+    BitMatrix, BitVec, IndexSet,
     python::{bitmatrix_as_capsule, bitmatrix_from_capsule},
 };
 use derive_more::{Deref, DerefMut, From, Into};
@@ -147,6 +147,42 @@ impl PyBitMatrix {
     #[staticmethod]
     fn ones(rows: usize, columns: usize) -> Self {
         BitMatrix::ones(rows, columns).into()
+    }
+
+    /// Construct a matrix from sparse column descriptions.
+    ///
+    /// Each element of `columns` is a list of row indices where the bit is 1.
+    #[staticmethod]
+    #[allow(clippy::needless_pass_by_value)]
+    fn from_sparse_columns(columns: Vec<Vec<usize>>, row_count: usize) -> Self {
+        let index_sets: Vec<IndexSet> = columns.into_iter().map(|col| col.into_iter().collect()).collect();
+        BitMatrix::from_sparse_columns(&index_sets, row_count).into()
+    }
+
+    /// Construct a matrix from sparse row descriptions.
+    ///
+    /// Each element of `rows` is a list of column indices where the bit is 1.
+    #[staticmethod]
+    #[allow(clippy::needless_pass_by_value)]
+    fn from_sparse_rows(rows: Vec<Vec<usize>>, column_count: usize) -> Self {
+        let index_sets: Vec<IndexSet> = rows.into_iter().map(|row| row.into_iter().collect()).collect();
+        BitMatrix::from_sparse_rows(&index_sets, column_count).into()
+    }
+
+    /// Return each column as a sorted list of row indices where the bit is 1.
+    fn sparse_columns(&self) -> Vec<Vec<usize>> {
+        BitMatrix::sparse_columns(self)
+            .into_iter()
+            .map(|s| s.into_iter().collect())
+            .collect()
+    }
+
+    /// Return each row as a sorted list of column indices where the bit is 1.
+    fn sparse_rows(&self) -> Vec<Vec<usize>> {
+        BitMatrix::sparse_rows(self)
+            .into_iter()
+            .map(|s| s.into_iter().collect())
+            .collect()
     }
 
     #[getter]

--- a/binar/bindings/python/src/py_bitmatrix.rs
+++ b/binar/bindings/python/src/py_bitmatrix.rs
@@ -4,6 +4,7 @@ use binar::{
     python::{bitmatrix_as_capsule, bitmatrix_from_capsule},
 };
 use derive_more::{Deref, DerefMut, From, Into};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyCapsule};
 
@@ -154,9 +155,11 @@ impl PyBitMatrix {
     /// Each element of `columns` is a list of row indices where the bit is 1.
     #[staticmethod]
     #[allow(clippy::needless_pass_by_value)]
-    fn from_sparse_columns(columns: Vec<Vec<usize>>, row_count: usize) -> Self {
+    fn from_sparse_columns(columns: Vec<Vec<usize>>, row_count: usize, column_count: usize) -> PyResult<Self> {
         let index_sets: Vec<IndexSet> = columns.into_iter().map(|col| col.into_iter().collect()).collect();
-        BitMatrix::from_sparse_columns(&index_sets, row_count).into()
+        BitMatrix::from_sparse_columns(&index_sets, row_count, column_count)
+            .map(Into::into)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
     /// Construct a matrix from sparse row descriptions.
@@ -164,9 +167,11 @@ impl PyBitMatrix {
     /// Each element of `rows` is a list of column indices where the bit is 1.
     #[staticmethod]
     #[allow(clippy::needless_pass_by_value)]
-    fn from_sparse_rows(rows: Vec<Vec<usize>>, column_count: usize) -> Self {
+    fn from_sparse_rows(rows: Vec<Vec<usize>>, row_count: usize, column_count: usize) -> PyResult<Self> {
         let index_sets: Vec<IndexSet> = rows.into_iter().map(|row| row.into_iter().collect()).collect();
-        BitMatrix::from_sparse_rows(&index_sets, column_count).into()
+        BitMatrix::from_sparse_rows(&index_sets, row_count, column_count)
+            .map(Into::into)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
     }
 
     /// Return each column as a sorted list of row indices where the bit is 1.
@@ -329,7 +334,7 @@ impl PyBitMatrix {
 }
 
 fn py_value_err(msg: impl Into<String>) -> PyErr {
-    pyo3::exceptions::PyValueError::new_err(msg.into())
+    PyValueError::new_err(msg.into())
 }
 
 fn py_type_err(msg: impl Into<String>) -> PyErr {

--- a/binar/bindings/python/src/py_bitmatrix.rs
+++ b/binar/bindings/python/src/py_bitmatrix.rs
@@ -1,9 +1,10 @@
 use crate::py_bitvec::PyBitVec;
 use binar::{
-    BitMatrix, BitVec,
+    BitMatrix, BitVec, IndexSet,
     python::{bitmatrix_as_capsule, bitmatrix_from_capsule},
 };
 use derive_more::{Deref, DerefMut, From, Into};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyCapsule};
 
@@ -147,6 +148,44 @@ impl PyBitMatrix {
     #[staticmethod]
     fn ones(rows: usize, columns: usize) -> Self {
         BitMatrix::ones(rows, columns).into()
+    }
+
+    /// Construct a matrix from sparse column descriptions.
+    ///
+    /// Each element of `columns` is an iterable of row indices where the bit is 1.
+    #[staticmethod]
+    fn from_sparse_columns(columns: &Bound<'_, PyAny>, row_count: usize, column_count: usize) -> PyResult<Self> {
+        let index_sets = parse_index_sets(columns)?;
+        BitMatrix::from_sparse_columns(&index_sets, row_count, column_count)
+            .map(Into::into)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
+    }
+
+    /// Construct a matrix from sparse row descriptions.
+    ///
+    /// Each element of `rows` is an iterable of column indices where the bit is 1.
+    #[staticmethod]
+    fn from_sparse_rows(rows: &Bound<'_, PyAny>, row_count: usize, column_count: usize) -> PyResult<Self> {
+        let index_sets = parse_index_sets(rows)?;
+        BitMatrix::from_sparse_rows(&index_sets, row_count, column_count)
+            .map(Into::into)
+            .map_err(|e| PyValueError::new_err(e.to_string()))
+    }
+
+    /// Return each column as a sorted list of row indices where the bit is 1.
+    fn sparse_columns(&self) -> Vec<Vec<usize>> {
+        BitMatrix::sparse_columns(self)
+            .into_iter()
+            .map(|s| s.into_iter().collect())
+            .collect()
+    }
+
+    /// Return each row as a sorted list of column indices where the bit is 1.
+    fn sparse_rows(&self) -> Vec<Vec<usize>> {
+        BitMatrix::sparse_rows(self)
+            .into_iter()
+            .map(|s| s.into_iter().collect())
+            .collect()
     }
 
     #[getter]
@@ -297,7 +336,20 @@ impl PyBitMatrix {
 }
 
 fn py_value_err(msg: impl Into<String>) -> PyErr {
-    pyo3::exceptions::PyValueError::new_err(msg.into())
+    PyValueError::new_err(msg.into())
+}
+
+/// Collect an iterable of iterables of indices into `IndexSet`s, matching the
+/// iterable-of-iterables input accepted by `BitMatrix.__new__`.
+fn parse_index_sets(data: &Bound<'_, PyAny>) -> PyResult<Vec<IndexSet>> {
+    data.try_iter()?
+        .map(|inner| {
+            inner?
+                .try_iter()?
+                .map(|index| index?.extract::<usize>())
+                .collect::<PyResult<IndexSet>>()
+        })
+        .collect()
 }
 
 fn py_type_err(msg: impl Into<String>) -> PyErr {

--- a/binar/src/lib.rs
+++ b/binar/src/lib.rs
@@ -108,7 +108,7 @@ pub mod vec;
 pub use vec::{BitVec, BitView, BitViewMut, IndexSet, remapped};
 
 pub mod matrix;
-pub use matrix::{BitMatrix, EchelonForm};
+pub use matrix::{BitMatrix, EchelonForm, SparseConversionError};
 
 pub mod affine_map;
 pub use affine_map::AffineMap;

--- a/binar/src/lib.rs
+++ b/binar/src/lib.rs
@@ -108,7 +108,7 @@ pub mod vec;
 pub use vec::{BitVec, BitView, BitViewMut, IndexSet, remapped};
 
 pub mod matrix;
-pub use matrix::{BitMatrix, EchelonForm};
+pub use matrix::{Axis, BitMatrix, EchelonForm, SparseConversionError};
 
 pub mod affine_map;
 pub use affine_map::AffineMap;

--- a/binar/src/matrix/aligned_bitmatrix.rs
+++ b/binar/src/matrix/aligned_bitmatrix.rs
@@ -2,7 +2,8 @@ use crate::BitLength;
 use crate::matrix::Column;
 use crate::vec::{AlignedBitVec, AlignedBitView, AlignedBitViewMut};
 use crate::vec::{BIT_BLOCK_WORD_COUNT, BitAccessor, BitBlock, Word};
-use crate::{Bitwise, BitwiseMut, BitwisePair, BitwisePairMut};
+use crate::vec::IndexSet;
+use crate::{Bitwise, BitwiseMut, BitwisePair, BitwisePairMut, FromBits};
 use rand::RngExt;
 use sorted_iter::SortedIterator;
 use sorted_iter::assume::AssumeSortedByItemExt;
@@ -389,6 +390,38 @@ impl AlignedBitMatrix {
         };
         debug_assert!(matrix.is_aligned());
         matrix
+    }
+
+    pub fn from_sparse_columns(columns: &[IndexSet], row_count: usize) -> Self {
+        let column_count = columns.len();
+        let mut matrix = Self::zeros(row_count, column_count);
+        for (col_idx, col) in columns.iter().enumerate() {
+            for row_idx in col.support() {
+                matrix.set((row_idx, col_idx), true);
+            }
+        }
+        matrix
+    }
+
+    pub fn from_sparse_rows(rows: &[IndexSet], column_count: usize) -> Self {
+        let row_count = rows.len();
+        let mut matrix = Self::zeros(row_count, column_count);
+        for (row_idx, row) in rows.iter().enumerate() {
+            for col_idx in row.support() {
+                matrix.set((row_idx, col_idx), true);
+            }
+        }
+        matrix
+    }
+
+    pub fn sparse_columns(&self) -> Vec<IndexSet> {
+        self.columns()
+            .map(|col| col.support().collect())
+            .collect()
+    }
+
+    pub fn sparse_rows(&self) -> Vec<IndexSet> {
+        self.rows().map(|row| IndexSet::from_bits(&row)).collect()
     }
 
     #[must_use]

--- a/binar/src/matrix/aligned_bitmatrix.rs
+++ b/binar/src/matrix/aligned_bitmatrix.rs
@@ -416,9 +416,7 @@ impl AlignedBitMatrix {
 
     #[must_use]
     pub fn sparse_columns(&self) -> Vec<IndexSet> {
-        self.columns()
-            .map(|col| col.support().collect())
-            .collect()
+        self.columns().map(|col| col.support().collect()).collect()
     }
 
     #[must_use]

--- a/binar/src/matrix/aligned_bitmatrix.rs
+++ b/binar/src/matrix/aligned_bitmatrix.rs
@@ -1,8 +1,8 @@
 use crate::BitLength;
 use crate::matrix::Column;
+use crate::vec::IndexSet;
 use crate::vec::{AlignedBitVec, AlignedBitView, AlignedBitViewMut};
 use crate::vec::{BIT_BLOCK_WORD_COUNT, BitAccessor, BitBlock, Word};
-use crate::vec::IndexSet;
 use crate::{Bitwise, BitwiseMut, BitwisePair, BitwisePairMut, FromBits};
 use rand::RngExt;
 use sorted_iter::SortedIterator;
@@ -414,12 +414,14 @@ impl AlignedBitMatrix {
         matrix
     }
 
+    #[must_use]
     pub fn sparse_columns(&self) -> Vec<IndexSet> {
         self.columns()
             .map(|col| col.support().collect())
             .collect()
     }
 
+    #[must_use]
     pub fn sparse_rows(&self) -> Vec<IndexSet> {
         self.rows().map(|row| IndexSet::from_bits(&row)).collect()
     }

--- a/binar/src/matrix/aligned_bitmatrix.rs
+++ b/binar/src/matrix/aligned_bitmatrix.rs
@@ -1,5 +1,6 @@
 use crate::BitLength;
 use crate::matrix::Column;
+use crate::matrix::SparseConversionError;
 use crate::vec::IndexSet;
 use crate::vec::{AlignedBitVec, AlignedBitView, AlignedBitViewMut};
 use crate::vec::{BIT_BLOCK_WORD_COUNT, BitAccessor, BitBlock, Word};
@@ -392,26 +393,72 @@ impl AlignedBitMatrix {
         matrix
     }
 
-    pub fn from_sparse_columns(columns: &[IndexSet], row_count: usize) -> Self {
-        let column_count = columns.len();
+    /// Creates a matrix from sparse column descriptions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `columns.len() > column_count` or if any column
+    /// contains a row index ≥ `row_count`.
+    pub fn from_sparse_columns(
+        columns: &[IndexSet],
+        row_count: usize,
+        column_count: usize,
+    ) -> Result<Self, SparseConversionError> {
+        if columns.len() > column_count {
+            return Err(SparseConversionError::TooManyEntries {
+                kind: "column",
+                provided: columns.len(),
+                declared: column_count,
+            });
+        }
         let mut matrix = Self::zeros(row_count, column_count);
         for (col_idx, col) in columns.iter().enumerate() {
             for row_idx in col.support() {
+                if row_idx >= row_count {
+                    return Err(SparseConversionError::IndexOutOfBounds {
+                        kind: "row",
+                        index: row_idx,
+                        bound: row_count,
+                    });
+                }
                 matrix.set((row_idx, col_idx), true);
             }
         }
-        matrix
+        Ok(matrix)
     }
 
-    pub fn from_sparse_rows(rows: &[IndexSet], column_count: usize) -> Self {
-        let row_count = rows.len();
+    /// Creates a matrix from sparse row descriptions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `rows.len() > row_count` or if any row contains a
+    /// column index ≥ `column_count`.
+    pub fn from_sparse_rows(
+        rows: &[IndexSet],
+        row_count: usize,
+        column_count: usize,
+    ) -> Result<Self, SparseConversionError> {
+        if rows.len() > row_count {
+            return Err(SparseConversionError::TooManyEntries {
+                kind: "row",
+                provided: rows.len(),
+                declared: row_count,
+            });
+        }
         let mut matrix = Self::zeros(row_count, column_count);
         for (row_idx, row) in rows.iter().enumerate() {
             for col_idx in row.support() {
+                if col_idx >= column_count {
+                    return Err(SparseConversionError::IndexOutOfBounds {
+                        kind: "column",
+                        index: col_idx,
+                        bound: column_count,
+                    });
+                }
                 matrix.set((row_idx, col_idx), true);
             }
         }
-        matrix
+        Ok(matrix)
     }
 
     #[must_use]

--- a/binar/src/matrix/aligned_bitmatrix.rs
+++ b/binar/src/matrix/aligned_bitmatrix.rs
@@ -1,8 +1,10 @@
 use crate::BitLength;
 use crate::matrix::Column;
+use crate::matrix::{Axis, SparseConversionError};
+use crate::vec::IndexSet;
 use crate::vec::{AlignedBitVec, AlignedBitView, AlignedBitViewMut};
 use crate::vec::{BIT_BLOCK_WORD_COUNT, BitAccessor, BitBlock, Word};
-use crate::{Bitwise, BitwiseMut, BitwisePair, BitwisePairMut};
+use crate::{Bitwise, BitwiseMut, BitwisePair, BitwisePairMut, FromBits};
 use rand::RngExt;
 use sorted_iter::SortedIterator;
 use sorted_iter::assume::AssumeSortedByItemExt;
@@ -389,6 +391,93 @@ impl AlignedBitMatrix {
         };
         debug_assert!(matrix.is_aligned());
         matrix
+    }
+
+    /// Creates a matrix from sparse column descriptions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `columns.len() > column_count` or if any column
+    /// contains a row index ≥ `row_count`.
+    pub fn from_sparse_columns(
+        columns: &[IndexSet],
+        row_count: usize,
+        column_count: usize,
+    ) -> Result<Self, SparseConversionError> {
+        if columns.len() > column_count {
+            return Err(SparseConversionError::TooManyEntries {
+                axis: Axis::Column,
+                provided: columns.len(),
+                declared: column_count,
+            });
+        }
+        let mut matrix = Self::zeros(row_count, column_count);
+        for (col_idx, col) in columns.iter().enumerate() {
+            for row_idx in col.support() {
+                if row_idx >= row_count {
+                    return Err(SparseConversionError::IndexOutOfBounds {
+                        axis: Axis::Row,
+                        index: row_idx,
+                        bound: row_count,
+                    });
+                }
+                matrix.set((row_idx, col_idx), true);
+            }
+        }
+        Ok(matrix)
+    }
+
+    /// Creates a matrix from sparse row descriptions.
+    ///
+    /// This mirrors `from_sparse_columns` with the axes swapped rather than
+    /// delegating to it through a transpose, so that neither constructor pays
+    /// for an extra allocation and transpose pass at runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `rows.len() > row_count` or if any row contains a
+    /// column index ≥ `column_count`.
+    pub fn from_sparse_rows(
+        rows: &[IndexSet],
+        row_count: usize,
+        column_count: usize,
+    ) -> Result<Self, SparseConversionError> {
+        if rows.len() > row_count {
+            return Err(SparseConversionError::TooManyEntries {
+                axis: Axis::Row,
+                provided: rows.len(),
+                declared: row_count,
+            });
+        }
+        let mut matrix = Self::zeros(row_count, column_count);
+        for (row_idx, row) in rows.iter().enumerate() {
+            for col_idx in row.support() {
+                if col_idx >= column_count {
+                    return Err(SparseConversionError::IndexOutOfBounds {
+                        axis: Axis::Column,
+                        index: col_idx,
+                        bound: column_count,
+                    });
+                }
+                matrix.set((row_idx, col_idx), true);
+            }
+        }
+        Ok(matrix)
+    }
+
+    #[must_use]
+    pub fn sparse_columns(&self) -> Vec<IndexSet> {
+        self.columns().map(|col| IndexSet::from_bits(&col)).collect()
+    }
+
+    /// Decomposes the matrix into the column indices of each set bit, by row.
+    ///
+    /// This reads the rows directly rather than reusing `sparse_columns` on a
+    /// transpose, so that neither accessor pays for an extra allocation and
+    /// transpose pass at runtime.
+    #[must_use]
+    pub fn sparse_rows(&self) -> Vec<IndexSet> {
+        self.rows().map(|row| IndexSet::from_bits(&row)).collect()
     }
 
     #[must_use]

--- a/binar/src/matrix/bitmatrix.rs
+++ b/binar/src/matrix/bitmatrix.rs
@@ -872,10 +872,12 @@ impl BitMatrix {
         }
     }
 
+    #[must_use]
     pub fn sparse_columns(&self) -> Vec<IndexSet> {
         self.aligned.sparse_columns()
     }
 
+    #[must_use]
     pub fn sparse_rows(&self) -> Vec<IndexSet> {
         self.aligned.sparse_rows()
     }

--- a/binar/src/matrix/bitmatrix.rs
+++ b/binar/src/matrix/bitmatrix.rs
@@ -3,7 +3,7 @@ use crate::matrix::{
     AlignedBitMatrix, AlignedEchelonForm, complete_to_full_rank_row_basis as aligned_complete_to_full_rank_row_basis,
     kernel_basis_matrix as aligned_kernel, row_stacked as aligned_row_stacked,
 };
-use crate::vec::Word;
+use crate::vec::{IndexSet, Word};
 use crate::{BitVec, BitView, BitViewMut};
 use derive_more::{From, Into};
 use std::cmp::PartialEq;
@@ -858,6 +858,26 @@ impl BitMatrix {
     pub fn kernel(&self) -> BitMatrix {
         let aligned = aligned_kernel(&self.aligned);
         BitMatrix::from_aligned(aligned)
+    }
+
+    pub fn from_sparse_columns(columns: &[IndexSet], row_count: usize) -> Self {
+        Self {
+            aligned: AlignedBitMatrix::from_sparse_columns(columns, row_count),
+        }
+    }
+
+    pub fn from_sparse_rows(rows: &[IndexSet], column_count: usize) -> Self {
+        Self {
+            aligned: AlignedBitMatrix::from_sparse_rows(rows, column_count),
+        }
+    }
+
+    pub fn sparse_columns(&self) -> Vec<IndexSet> {
+        self.aligned.sparse_columns()
+    }
+
+    pub fn sparse_rows(&self) -> Vec<IndexSet> {
+        self.aligned.sparse_rows()
     }
 }
 

--- a/binar/src/matrix/bitmatrix.rs
+++ b/binar/src/matrix/bitmatrix.rs
@@ -1,7 +1,8 @@
 use crate::matrix::column::Column;
 use crate::matrix::{
-    AlignedBitMatrix, AlignedEchelonForm, complete_to_full_rank_row_basis as aligned_complete_to_full_rank_row_basis,
-    kernel_basis_matrix as aligned_kernel, row_stacked as aligned_row_stacked,
+    AlignedBitMatrix, AlignedEchelonForm, SparseConversionError,
+    complete_to_full_rank_row_basis as aligned_complete_to_full_rank_row_basis, kernel_basis_matrix as aligned_kernel,
+    row_stacked as aligned_row_stacked,
 };
 use crate::vec::{IndexSet, Word};
 use crate::{BitVec, BitView, BitViewMut};
@@ -860,16 +861,32 @@ impl BitMatrix {
         BitMatrix::from_aligned(aligned)
     }
 
-    pub fn from_sparse_columns(columns: &[IndexSet], row_count: usize) -> Self {
-        Self {
-            aligned: AlignedBitMatrix::from_sparse_columns(columns, row_count),
-        }
+    /// # Errors
+    ///
+    /// Returns an error if `columns.len() > column_count` or if any column
+    /// contains a row index ≥ `row_count`.
+    pub fn from_sparse_columns(
+        columns: &[IndexSet],
+        row_count: usize,
+        column_count: usize,
+    ) -> Result<Self, SparseConversionError> {
+        Ok(Self {
+            aligned: AlignedBitMatrix::from_sparse_columns(columns, row_count, column_count)?,
+        })
     }
 
-    pub fn from_sparse_rows(rows: &[IndexSet], column_count: usize) -> Self {
-        Self {
-            aligned: AlignedBitMatrix::from_sparse_rows(rows, column_count),
-        }
+    /// # Errors
+    ///
+    /// Returns an error if `rows.len() > row_count` or if any row contains a
+    /// column index ≥ `column_count`.
+    pub fn from_sparse_rows(
+        rows: &[IndexSet],
+        row_count: usize,
+        column_count: usize,
+    ) -> Result<Self, SparseConversionError> {
+        Ok(Self {
+            aligned: AlignedBitMatrix::from_sparse_rows(rows, row_count, column_count)?,
+        })
     }
 
     #[must_use]

--- a/binar/src/matrix/bitmatrix.rs
+++ b/binar/src/matrix/bitmatrix.rs
@@ -1,9 +1,10 @@
 use crate::matrix::column::Column;
 use crate::matrix::{
-    AlignedBitMatrix, AlignedEchelonForm, complete_to_full_rank_row_basis as aligned_complete_to_full_rank_row_basis,
-    kernel_basis_matrix as aligned_kernel, row_stacked as aligned_row_stacked,
+    AlignedBitMatrix, AlignedEchelonForm, SparseConversionError,
+    complete_to_full_rank_row_basis as aligned_complete_to_full_rank_row_basis, kernel_basis_matrix as aligned_kernel,
+    row_stacked as aligned_row_stacked,
 };
-use crate::vec::Word;
+use crate::vec::{IndexSet, Word};
 use crate::{BitVec, BitView, BitViewMut};
 use derive_more::{From, Into};
 use std::cmp::PartialEq;
@@ -893,6 +894,44 @@ impl BitMatrix {
         BitMatrix {
             aligned: self.aligned.row_space_intersection_with(&other.aligned),
         }
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if `columns.len() > column_count` or if any column
+    /// contains a row index ≥ `row_count`.
+    pub fn from_sparse_columns(
+        columns: &[IndexSet],
+        row_count: usize,
+        column_count: usize,
+    ) -> Result<Self, SparseConversionError> {
+        Ok(Self {
+            aligned: AlignedBitMatrix::from_sparse_columns(columns, row_count, column_count)?,
+        })
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error if `rows.len() > row_count` or if any row contains a
+    /// column index ≥ `column_count`.
+    pub fn from_sparse_rows(
+        rows: &[IndexSet],
+        row_count: usize,
+        column_count: usize,
+    ) -> Result<Self, SparseConversionError> {
+        Ok(Self {
+            aligned: AlignedBitMatrix::from_sparse_rows(rows, row_count, column_count)?,
+        })
+    }
+
+    #[must_use]
+    pub fn sparse_columns(&self) -> Vec<IndexSet> {
+        self.aligned.sparse_columns()
+    }
+
+    #[must_use]
+    pub fn sparse_rows(&self) -> Vec<IndexSet> {
+        self.aligned.sparse_rows()
     }
 }
 

--- a/binar/src/matrix/mod.rs
+++ b/binar/src/matrix/mod.rs
@@ -5,6 +5,26 @@ mod m4ri;
 pub mod tiny_matrix;
 pub mod transpose_kernel;
 
+use derive_more::{Display, Error};
+
+/// Error returned when constructing a matrix from sparse data with
+/// incompatible dimensions.
+#[derive(Debug, Display, Error)]
+pub enum SparseConversionError {
+    #[display("more {kind}s provided ({provided}) than {kind}_count ({declared})")]
+    TooManyEntries {
+        kind: &'static str,
+        provided: usize,
+        declared: usize,
+    },
+    #[display("{kind} index {index} out of bounds for {kind}_count {bound}")]
+    IndexOutOfBounds {
+        kind: &'static str,
+        index: usize,
+        bound: usize,
+    },
+}
+
 pub use aligned_bitmatrix::{
     AlignedBitMatrix, EchelonForm as AlignedEchelonForm, MutableRow, Row, complete_to_full_rank_row_basis,
     directly_summed, kernel_basis_matrix, row_stacked,

--- a/binar/src/matrix/mod.rs
+++ b/binar/src/matrix/mod.rs
@@ -5,6 +5,32 @@ mod m4ri;
 pub mod tiny_matrix;
 pub mod transpose_kernel;
 
+use derive_more::{Display, Error};
+
+/// Error returned when constructing a matrix from sparse data with
+/// incompatible dimensions.
+#[derive(Debug, Display, Error)]
+pub enum SparseConversionError {
+    #[display("more {axis}s provided ({provided}) than {axis}_count ({declared})")]
+    TooManyEntries {
+        axis: Axis,
+        provided: usize,
+        declared: usize,
+    },
+    #[display("{axis} index {index} out of bounds for {axis}_count {bound}")]
+    IndexOutOfBounds { axis: Axis, index: usize, bound: usize },
+}
+
+/// A matrix axis, used to describe `SparseConversionError`s without
+/// stringly-typed labels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Display)]
+pub enum Axis {
+    #[display("row")]
+    Row,
+    #[display("column")]
+    Column,
+}
+
 pub use aligned_bitmatrix::{
     AlignedBitMatrix, EchelonForm as AlignedEchelonForm, MutableRow, Row, complete_to_full_rank_row_basis,
     directly_summed, kernel_basis_matrix, row_stacked,

--- a/binar/tests/bitmatrix_test.rs
+++ b/binar/tests/bitmatrix_test.rs
@@ -223,6 +223,20 @@ proptest! {
         }
     }
 
+    #[test]
+    fn sparse_columns_roundtrip(matrix in arbitrary_bitmatrix(50)) {
+        let columns = matrix.sparse_columns();
+        let reconstructed = AlignedBitMatrix::from_sparse_columns(&columns, matrix.row_count());
+        assert_eq!(matrix, reconstructed);
+    }
+
+    #[test]
+    fn sparse_rows_roundtrip(matrix in arbitrary_bitmatrix(50)) {
+        let rows = matrix.sparse_rows();
+        let reconstructed = AlignedBitMatrix::from_sparse_rows(&rows, matrix.column_count());
+        assert_eq!(matrix, reconstructed);
+    }
+
 }
 
 macro_rules! bitmatrix{
@@ -747,16 +761,12 @@ fn random_bitvec(size: usize) -> AlignedBitVec {
 
 #[test]
 fn row_stacked_respects_swap_rows() {
-    // Regression test: row_stacked previously copied the raw blocks buffer
-    // rather than following row pointers, so swap_rows was silently undone.
     let mut m = AlignedBitMatrix::identity(4);
-    // Swap rows 0 and 3: row 0 should now be [0,0,0,1], row 3 should be [1,0,0,0]
     m.swap_rows(0, 3);
     assert!(m.get((0, 3)));
     assert!(!m.get((0, 0)));
 
     let stacked = row_stacked([&m]);
-    // The stacked result must reflect the swapped order
     assert!(stacked.get((0, 3)), "row_stacked did not preserve swap_rows");
     assert!(!stacked.get((0, 0)), "row_stacked did not preserve swap_rows");
     assert!(stacked.get((3, 0)));
@@ -767,12 +777,32 @@ fn row_stacked_respects_swap_rows() {
 #[test]
 fn row_stacked_respects_permute_rows() {
     let mut m = AlignedBitMatrix::identity(3);
-    m.permute_rows(&[2, 0, 1]); // row 0 ← old row 2, row 1 ← old row 0, row 2 ← old row 1
+    m.permute_rows(&[2, 0, 1]);
 
     let stacked = row_stacked([&m]);
     for r in 0..3 {
         for c in 0..3 {
             assert_eq!(stacked.get((r, c)), m.get((r, c)), "mismatch at ({r}, {c})");
         }
+    }
+}
+
+#[test]
+fn sparse_conversion_empty() {
+    let m = AlignedBitMatrix::zeros(0, 0);
+    assert_eq!(m.sparse_columns().len(), 0);
+    assert_eq!(m.sparse_rows().len(), 0);
+    let m2 = AlignedBitMatrix::from_sparse_columns(&[], 0);
+    assert_eq!(m2, m);
+}
+
+#[test]
+fn sparse_conversion_identity() {
+    let m = AlignedBitMatrix::identity(5);
+    let cols = m.sparse_columns();
+    assert_eq!(cols.len(), 5);
+    for (i, col) in cols.iter().enumerate() {
+        assert_eq!(col.weight(), 1);
+        assert!(col.index(i));
     }
 }

--- a/binar/tests/bitmatrix_test.rs
+++ b/binar/tests/bitmatrix_test.rs
@@ -4,7 +4,7 @@ use binar::matrix::{
     kernel_basis_matrix, row_stacked,
 };
 use binar::vec::AlignedBitVec;
-use binar::{Bitwise, BitwiseMut, BitwisePairMut};
+use binar::{Bitwise, BitwiseMut, BitwisePairMut, IndexSet};
 use proptest::prelude::*;
 use rand::{RngExt, SeedableRng};
 use sorted_iter::SortedIterator;
@@ -226,14 +226,14 @@ proptest! {
     #[test]
     fn sparse_columns_roundtrip(matrix in arbitrary_bitmatrix(50)) {
         let columns = matrix.sparse_columns();
-        let reconstructed = AlignedBitMatrix::from_sparse_columns(&columns, matrix.row_count());
+        let reconstructed = AlignedBitMatrix::from_sparse_columns(&columns, matrix.row_count(), matrix.column_count()).unwrap();
         assert_eq!(matrix, reconstructed);
     }
 
     #[test]
     fn sparse_rows_roundtrip(matrix in arbitrary_bitmatrix(50)) {
         let rows = matrix.sparse_rows();
-        let reconstructed = AlignedBitMatrix::from_sparse_rows(&rows, matrix.column_count());
+        let reconstructed = AlignedBitMatrix::from_sparse_rows(&rows, matrix.row_count(), matrix.column_count()).unwrap();
         assert_eq!(matrix, reconstructed);
     }
 
@@ -792,7 +792,7 @@ fn sparse_conversion_empty() {
     let m = AlignedBitMatrix::zeros(0, 0);
     assert_eq!(m.sparse_columns().len(), 0);
     assert_eq!(m.sparse_rows().len(), 0);
-    let m2 = AlignedBitMatrix::from_sparse_columns(&[], 0);
+    let m2 = AlignedBitMatrix::from_sparse_columns(&[], 0, 0).unwrap();
     assert_eq!(m2, m);
 }
 
@@ -805,4 +805,59 @@ fn sparse_conversion_identity() {
         assert_eq!(col.weight(), 1);
         assert!(col.index(i));
     }
+}
+
+#[test]
+fn from_sparse_columns_with_trailing_zero_columns() {
+    let columns: Vec<IndexSet> = vec![[0, 1].into_iter().collect()];
+    let m = AlignedBitMatrix::from_sparse_columns(&columns, 3, 4).unwrap();
+    assert_eq!(m.row_count(), 3);
+    assert_eq!(m.column_count(), 4);
+    assert!(m.get((0, 0)));
+    assert!(m.get((1, 0)));
+    assert!(!m.get((2, 0)));
+    for col in 1..4 {
+        for row in 0..3 {
+            assert!(!m.get((row, col)));
+        }
+    }
+}
+
+#[test]
+fn from_sparse_rows_with_trailing_zero_rows() {
+    let rows: Vec<IndexSet> = vec![[0, 2].into_iter().collect()];
+    let m = AlignedBitMatrix::from_sparse_rows(&rows, 4, 3).unwrap();
+    assert_eq!(m.row_count(), 4);
+    assert_eq!(m.column_count(), 3);
+    assert!(m.get((0, 0)));
+    assert!(m.get((0, 2)));
+    for row in 1..4 {
+        for col in 0..3 {
+            assert!(!m.get((row, col)));
+        }
+    }
+}
+
+#[test]
+fn from_sparse_columns_too_many_columns() {
+    let columns: Vec<IndexSet> = vec![IndexSet::default(); 3];
+    assert!(AlignedBitMatrix::from_sparse_columns(&columns, 2, 2).is_err());
+}
+
+#[test]
+fn from_sparse_rows_too_many_rows() {
+    let rows: Vec<IndexSet> = vec![IndexSet::default(); 3];
+    assert!(AlignedBitMatrix::from_sparse_rows(&rows, 2, 2).is_err());
+}
+
+#[test]
+fn from_sparse_columns_index_out_of_bounds() {
+    let columns: Vec<IndexSet> = vec![[5].into_iter().collect()];
+    assert!(AlignedBitMatrix::from_sparse_columns(&columns, 3, 1).is_err());
+}
+
+#[test]
+fn from_sparse_rows_index_out_of_bounds() {
+    let rows: Vec<IndexSet> = vec![[5].into_iter().collect()];
+    assert!(AlignedBitMatrix::from_sparse_rows(&rows, 1, 3).is_err());
 }

--- a/binar/tests/bitmatrix_test.rs
+++ b/binar/tests/bitmatrix_test.rs
@@ -4,7 +4,7 @@ use binar::matrix::{
     kernel_basis_matrix, row_stacked,
 };
 use binar::vec::AlignedBitVec;
-use binar::{BitBlock, BitLength, Bitwise, BitwiseMut, BitwisePairMut};
+use binar::{BitBlock, BitLength, Bitwise, BitwiseMut, BitwisePairMut, IndexSet};
 use proptest::prelude::*;
 use rand::{RngExt, SeedableRng};
 use sorted_iter::SortedIterator;
@@ -221,6 +221,20 @@ proptest! {
                 assert!(!summed[(left.row_count() + row_index, column_index)]);
             }
         }
+    }
+
+    #[test]
+    fn sparse_columns_roundtrip(matrix in arbitrary_bitmatrix(50)) {
+        let columns = matrix.sparse_columns();
+        let reconstructed = AlignedBitMatrix::from_sparse_columns(&columns, matrix.row_count(), matrix.column_count()).unwrap();
+        assert_eq!(matrix, reconstructed);
+    }
+
+    #[test]
+    fn sparse_rows_roundtrip(matrix in arbitrary_bitmatrix(50)) {
+        let rows = matrix.sparse_rows();
+        let reconstructed = AlignedBitMatrix::from_sparse_rows(&rows, matrix.row_count(), matrix.column_count()).unwrap();
+        assert_eq!(matrix, reconstructed);
     }
 
 }
@@ -879,4 +893,79 @@ proptest! {
         let rl = right.row_space_intersection_with(&left);
         prop_assert_eq!(lr.rank(), rl.rank());
     }
+}
+
+#[test]
+fn sparse_conversion_empty() {
+    let m = AlignedBitMatrix::zeros(0, 0);
+    assert_eq!(m.sparse_columns().len(), 0);
+    assert_eq!(m.sparse_rows().len(), 0);
+    let m2 = AlignedBitMatrix::from_sparse_columns(&[], 0, 0).unwrap();
+    assert_eq!(m2, m);
+}
+
+#[test]
+fn sparse_conversion_identity() {
+    let m = AlignedBitMatrix::identity(5);
+    let cols = m.sparse_columns();
+    assert_eq!(cols.len(), 5);
+    for (i, col) in cols.iter().enumerate() {
+        assert_eq!(col.weight(), 1);
+        assert!(col.index(i));
+    }
+}
+
+#[test]
+fn from_sparse_columns_with_trailing_zero_columns() {
+    let columns: Vec<IndexSet> = vec![[0, 1].into_iter().collect()];
+    let m = AlignedBitMatrix::from_sparse_columns(&columns, 3, 4).unwrap();
+    assert_eq!(m.row_count(), 3);
+    assert_eq!(m.column_count(), 4);
+    assert!(m.get((0, 0)));
+    assert!(m.get((1, 0)));
+    assert!(!m.get((2, 0)));
+    for col in 1..4 {
+        for row in 0..3 {
+            assert!(!m.get((row, col)));
+        }
+    }
+}
+
+#[test]
+fn from_sparse_rows_with_trailing_zero_rows() {
+    let rows: Vec<IndexSet> = vec![[0, 2].into_iter().collect()];
+    let m = AlignedBitMatrix::from_sparse_rows(&rows, 4, 3).unwrap();
+    assert_eq!(m.row_count(), 4);
+    assert_eq!(m.column_count(), 3);
+    assert!(m.get((0, 0)));
+    assert!(m.get((0, 2)));
+    for row in 1..4 {
+        for col in 0..3 {
+            assert!(!m.get((row, col)));
+        }
+    }
+}
+
+#[test]
+fn from_sparse_columns_too_many_columns() {
+    let columns: Vec<IndexSet> = vec![IndexSet::default(); 3];
+    assert!(AlignedBitMatrix::from_sparse_columns(&columns, 2, 2).is_err());
+}
+
+#[test]
+fn from_sparse_rows_too_many_rows() {
+    let rows: Vec<IndexSet> = vec![IndexSet::default(); 3];
+    assert!(AlignedBitMatrix::from_sparse_rows(&rows, 2, 2).is_err());
+}
+
+#[test]
+fn from_sparse_columns_index_out_of_bounds() {
+    let columns: Vec<IndexSet> = vec![[5].into_iter().collect()];
+    assert!(AlignedBitMatrix::from_sparse_columns(&columns, 3, 1).is_err());
+}
+
+#[test]
+fn from_sparse_rows_index_out_of_bounds() {
+    let rows: Vec<IndexSet> = vec![[5].into_iter().collect()];
+    assert!(AlignedBitMatrix::from_sparse_rows(&rows, 1, 3).is_err());
 }


### PR DESCRIPTION
## Summary

Add methods for converting between dense `BitMatrix` and sparse
column/row representations via `IndexSet`, and expose them in the
Python bindings.

## Motivation

`BitMatrix` has no way to construct a matrix from sparse column or row
descriptions, or to decompose one into its column/row supports.
Consumers that work with sparse GF(2) matrices (e.g., syndrome
indicators, check matrices) must set bits one at a time.

## Changes

**Rust API** (`AlignedBitMatrix` + `BitMatrix`):
- `from_sparse_columns(&[IndexSet], row_count, column_count) -> Result<Self, SparseConversionError>`
- `from_sparse_rows(&[IndexSet], row_count, column_count) -> Result<Self, SparseConversionError>`
- `sparse_columns(&self) -> Vec<IndexSet>`
- `sparse_rows(&self) -> Vec<IndexSet>`

Both constructors take an explicit `(row_count, column_count)` shape
(matching the scipy.sparse convention), allowing trailing zero
rows/columns. Invalid inputs return `SparseConversionError`.

**Python API** (`BitMatrix`):
- `from_sparse_columns(columns, row_count, column_count)`
- `from_sparse_rows(rows, row_count, column_count)`
- `sparse_columns() -> list[list[int]]`
- `sparse_rows() -> list[list[int]]`

Invalid inputs raise `ValueError`.

## Testing

- Proptest round-trips for both `sparse_columns` and `sparse_rows`
- Trailing zero rows/columns
- Error cases: too many entries, index out of bounds
- Edge cases: empty matrix, identity matrix
- `cargo clippy-all` clean, `cargo fmt` clean, `mypy.stubtest` clean