### PR TITLE
fix(pauliverse): action_of handles circuits with untouched qubits

### DIFF
--- a/pauliverse/src/action.rs
+++ b/pauliverse/src/action.rs
@@ -27,6 +27,8 @@ pub struct CircuitAction {
     random_from_outcomes: AffineMap,
     /// The map from inner random bits to circuit outcomes
     outcomes_from_random: AffineMap,
+    /// The caller-supplied input qubit IDs
+    input_qubit_ids: Vec<QubitId>,
 }
 
 #[derive(Clone, PartialEq)]
@@ -156,27 +158,31 @@ pub fn action_of(
         auxiliary_stabilizers,
         random_from_outcomes: outcome_to_random_bit_map,
         outcomes_from_random,
+        input_qubit_ids: input_qubits.to_vec(),
     };
     Ok(action)
 }
 
 impl CircuitAction {
-    /// Canonical choice of circuit observables, that is Paulis measured by the circuit
-    /// Qubits are reindexed to the range `[0, input_qubits.len())` and ordered according to [`CircuitAction::input_qubits`].
+    /// Canonical choice of circuit observables, that is Paulis measured by the circuit.
+    /// Qubits are reindexed to the range `[0, input_qubits.len())` where the k-th qubit corresponds
+    /// to the k-th entry of [`CircuitAction::input_qubits`].
     pub fn observables(&self) -> &[SparsePauli] {
         self.observables.abs()
     }
 
     /// Canonical choice of circuit stabilizers, that is Paulis that stabilize output state of the circuit
-    /// for all circuit inputs
-    /// Qubits are reindexed to the range `[0, output_qubits.len())` and ordered according to [`CircuitAction::output_qubits`].
+    /// for all circuit inputs.
+    /// Qubits are reindexed to the range `[0, output_qubits.len())` where the k-th qubit corresponds
+    /// to the k-th entry of [`CircuitAction::output_qubits`].
     pub fn stabilizers(&self) -> &[SparsePauli] {
         self.stabilizers.abs()
     }
 
-    /// Canonical choice of circuit choi state stabilizers
-    /// Qubits are reindexed to the range `[0, input_qubits.len() + output_qubits.len())` and ordered according to [`CircuitAction::input_qubits`]
-    /// concatenated with [`CircuitAction::output_qubits`].
+    /// Canonical choice of circuit choi state stabilizers.
+    /// Qubits are reindexed to the range `[0, input_qubits.len() + output_qubits.len())` where the first
+    /// `input_qubits.len()` qubits correspond positionally to [`CircuitAction::input_qubits`]
+    /// and the remaining qubits correspond positionally to [`CircuitAction::output_qubits`].
     pub fn choi_state_stabilizers(&self) -> &[SparsePauli] {
         self.choi_state_stabilizers.abs()
     }
@@ -300,7 +306,7 @@ impl CircuitAction {
 
     #[must_use]
     pub fn input_qubits(&self) -> &[QubitId] {
-        &self.observables.canonical_to_original
+        &self.input_qubit_ids
     }
 
     #[must_use]

--- a/pauliverse/src/action.rs
+++ b/pauliverse/src/action.rs
@@ -97,7 +97,10 @@ pub fn action_of(
     input_qubits: &[QubitId],
     output_qubits: &[QubitId],
 ) -> Result<CircuitAction, ActionError> {
-    let qubit_count = circuit.qubit_count();
+    let qubit_count = circuit
+        .qubit_count()
+        .max(input_qubits.iter().max().map_or(0, |&q| q + 1))
+        .max(output_qubits.iter().max().map_or(0, |&q| q + 1));
     let reference_qubits: Vec<QubitId> = (qubit_count..qubit_count + input_qubits.len()).collect();
     let outcome_count = circuit.outcome_count();
     let mut simulation =

--- a/pauliverse/tests/action_test.rs
+++ b/pauliverse/tests/action_test.rs
@@ -10,7 +10,7 @@ use paulimer::pauli::remapped_sparse;
 use paulimer::traits::NeutralElement;
 use paulimer::{Clifford, CliffordMutable, CliffordUnitary, DensePauli, Pauli, PauliGroup, PauliMutable, SparsePauli};
 use paulimer::{PositionedPauliObservable, UnitaryOp};
-use pauliverse::action::{CircuitAction, action_of};
+use pauliverse::action::{self, CircuitAction, action_of};
 use pauliverse::{Circuit, CircuitBuilder, OutcomeId, QubitId, Simulation};
 use proptest::prelude::*;
 use rand::{RngExt, SeedableRng};
@@ -871,11 +871,15 @@ fn action_of_empty_circuit_with_untouched_qubits() {
     let circuit = empty_builder().into_circuit();
     let input_qubits = vec![0, 1];
     let output_qubits = vec![0, 1];
-    let action = action_of(&circuit, &input_qubits, &output_qubits);
+    let result = action_of(&circuit, &input_qubits, &output_qubits);
     assert!(
-        action.is_ok(),
+        result.is_ok(),
         "action_of should succeed on an empty circuit with declared qubits"
     );
+    let action = result.expect("Cannot get the action.");
+    assert!(action.auxiliary_qubits().len() == 0);
+    assert_eq!(action.input_qubits(), input_qubits);
+    assert_eq!(action.output_qubits(), output_qubits);
 }
 
 #[test]

--- a/pauliverse/tests/action_test.rs
+++ b/pauliverse/tests/action_test.rs
@@ -864,6 +864,44 @@ fn max_qubit_id_of(z_diagonal_paulis: &[SparsePauli]) -> usize {
         .expect("At least one pauli should be provided")
 }
 
+// Regression tests for https://github.com/microsoft/qdk-ec/issues/33
+
+#[test]
+fn action_of_empty_circuit_with_untouched_qubits() {
+    let circuit = empty_builder().into_circuit();
+    let input_qubits = vec![0, 1];
+    let output_qubits = vec![0, 1];
+    let action = action_of(&circuit, &input_qubits, &output_qubits);
+    assert!(
+        action.is_ok(),
+        "action_of should succeed on an empty circuit with declared qubits"
+    );
+}
+
+#[test]
+fn action_of_circuit_not_touching_all_input_qubits() {
+    let circuit = empty_builder().h(0).into_circuit();
+    let input_qubits = vec![0, 1, 2];
+    let output_qubits = vec![0, 1, 2];
+    let action = action_of(&circuit, &input_qubits, &output_qubits);
+    assert!(
+        action.is_ok(),
+        "action_of should succeed when circuit doesn't touch all input qubits"
+    );
+}
+
+#[test]
+fn action_of_circuit_not_touching_all_output_qubits() {
+    let circuit = empty_builder().h(0).into_circuit();
+    let input_qubits = vec![0];
+    let output_qubits = vec![0, 1, 2];
+    let action = action_of(&circuit, &input_qubits, &output_qubits);
+    assert!(
+        action.is_ok(),
+        "action_of should succeed when circuit doesn't touch all output qubits"
+    );
+}
+
 // Strategies
 
 prop_compose! {

--- a/pauliverse/tests/action_test.rs
+++ b/pauliverse/tests/action_test.rs
@@ -10,7 +10,7 @@ use paulimer::pauli::remapped_sparse;
 use paulimer::traits::NeutralElement;
 use paulimer::{Clifford, CliffordMutable, CliffordUnitary, DensePauli, Pauli, PauliGroup, PauliMutable, SparsePauli};
 use paulimer::{PositionedPauliObservable, UnitaryOp};
-use pauliverse::action::{self, CircuitAction, action_of};
+use pauliverse::action::{CircuitAction, action_of};
 use pauliverse::{Circuit, CircuitBuilder, OutcomeId, QubitId, Simulation};
 use proptest::prelude::*;
 use rand::{RngExt, SeedableRng};
@@ -707,6 +707,11 @@ impl<Simulator: Simulation> SimulationBuilder<Simulator> {
         self
     }
 
+    pub fn id(mut self, qubit: QubitId) -> Self {
+        self.simulator.unitary_op(UnitaryOp::I, &[qubit]);
+        self
+    }
+
     pub fn sqrt_y(mut self, qubit: QubitId) -> Self {
         self.simulator.unitary_op(UnitaryOp::SqrtY, &[qubit]);
         self
@@ -871,15 +876,11 @@ fn action_of_empty_circuit_with_untouched_qubits() {
     let circuit = empty_builder().into_circuit();
     let input_qubits = vec![0, 1];
     let output_qubits = vec![0, 1];
-    let result = action_of(&circuit, &input_qubits, &output_qubits);
-    assert!(
-        result.is_ok(),
-        "action_of should succeed on an empty circuit with declared qubits"
-    );
-    let action = result.expect("Cannot get the action.");
-    assert!(action.auxiliary_qubits().len() == 0);
-    assert_eq!(action.input_qubits(), input_qubits);
-    assert_eq!(action.output_qubits(), output_qubits);
+    let action = action_of(&circuit, &input_qubits, &output_qubits)
+        .expect("action_of should succeed on an empty circuit with declared qubits");
+    assert_eq!(action.input_qubits(), &input_qubits);
+    assert_eq!(action.output_qubits(), &output_qubits);
+    assert!(action.auxiliary_qubits().is_empty());
 }
 
 #[test]
@@ -887,11 +888,10 @@ fn action_of_circuit_not_touching_all_input_qubits() {
     let circuit = empty_builder().h(0).into_circuit();
     let input_qubits = vec![0, 1, 2];
     let output_qubits = vec![0, 1, 2];
-    let action = action_of(&circuit, &input_qubits, &output_qubits);
-    assert!(
-        action.is_ok(),
-        "action_of should succeed when circuit doesn't touch all input qubits"
-    );
+    let action = action_of(&circuit, &input_qubits, &output_qubits)
+        .expect("action_of should succeed when circuit doesn't touch all input qubits");
+    assert_eq!(action.input_qubits(), &input_qubits);
+    assert_eq!(action.output_qubits(), &output_qubits);
 }
 
 #[test]
@@ -899,11 +899,33 @@ fn action_of_circuit_not_touching_all_output_qubits() {
     let circuit = empty_builder().h(0).into_circuit();
     let input_qubits = vec![0];
     let output_qubits = vec![0, 1, 2];
-    let action = action_of(&circuit, &input_qubits, &output_qubits);
-    assert!(
-        action.is_ok(),
-        "action_of should succeed when circuit doesn't touch all output qubits"
+    let action = action_of(&circuit, &input_qubits, &output_qubits)
+        .expect("action_of should succeed when circuit doesn't touch all output qubits");
+    assert_eq!(action.input_qubits(), &input_qubits);
+    assert_eq!(action.output_qubits(), &output_qubits);
+}
+
+#[test]
+fn action_of_untouched_qubits_matches_identity() {
+    let input_qubits = vec![0, 1, 2];
+    let output_qubits = vec![0, 1, 2];
+
+    let circuit_untouched = empty_builder().h(0).into_circuit();
+    let action_untouched =
+        action_of(&circuit_untouched, &input_qubits, &output_qubits).expect("untouched should succeed");
+
+    let circuit_with_identities = empty_builder().h(0).id(1).id(2).into_circuit();
+    let action_with_identities =
+        action_of(&circuit_with_identities, &input_qubits, &output_qubits).expect("with_identities should succeed");
+
+    assert_eq!(action_untouched.input_qubits(), action_with_identities.input_qubits());
+    assert_eq!(action_untouched.output_qubits(), action_with_identities.output_qubits());
+    assert_eq!(
+        action_untouched.auxiliary_qubits(),
+        action_with_identities.auxiliary_qubits()
     );
+    assert_eq!(action_untouched.observables(), action_with_identities.observables());
+    assert_eq!(action_untouched.stabilizers(), action_with_identities.stabilizers());
 }
 
 // Strategies


### PR DESCRIPTION
Fixes #33

## Problem

`action_of` panics when the circuit does not touch all declared input or output qubits. The simulation was allocated with `qubit_count = circuit.qubit_count()`, which only accounts for qubits the circuit touches. Declared input or output qubits beyond this range didn't exist in the simulation's state space, causing panics in the restriction logic.

## Fix

Compute the simulation's qubit count as the maximum of the circuit's qubit count and the declared input/output qubit IDs. Untouched qubits are initialized as identity by `CliffordUnitary::identity`, matching the behavior of the original workaround (inserting identity gates).

## Tests

Three regression tests covering:
- Empty circuit with declared qubits
- Circuit not touching all input qubits
- Circuit not touching all output qubits