### PR TITLE
Add more Python decoders and a doc for integrating other Python decoders easily

### DIFF
--- a/deq/deq/cli/__init__.py
+++ b/deq/deq/cli/__init__.py
@@ -15,26 +15,31 @@ from . import strip_tags
 from . import sample
 
 
-def _run_server(args: list[str]) -> None:
-    """Delegate ``deq server ...`` to the Rust runtime CLI."""
+# Subcommands implemented in the Rust runtime (`deq_runtime`) rather than in
+# the Python `deq` CLI. They are dispatched verbatim via ``deq_runtime.cli_run``.
+_RUNTIME_SUBCOMMANDS = ("server", "test", "benchmark")
+
+
+def _run_runtime_cli(subcommand: str, args: list[str]) -> None:
+    """Delegate ``deq <subcommand> ...`` to the Rust runtime CLI."""
     try:
         import deq_runtime
     except ImportError:
         print(
             "Error: deq_runtime is not installed. "
-            "Build it with: cd deq_runtime && maturin develop --release",
+            "Build it with: cd deq_runtime && maturin develop --release --features python_all",
             file=sys.stderr,
         )
         raise SystemExit(1)
     try:
-        deq_runtime.cli_run("server", *args)  # type: ignore[attr-defined]
+        deq_runtime.cli_run(subcommand, *args)  # type: ignore[attr-defined]
     except ValueError:
         pass
 
 
 def run() -> None:
-    # Intercept "server" before arguably to forward args to the Rust CLI.
-    if len(sys.argv) >= 2 and sys.argv[1] == "server":
-        _run_server(sys.argv[2:])
+    # Intercept runtime-owned subcommands before arguably to forward args to the Rust CLI.
+    if len(sys.argv) >= 2 and sys.argv[1] in _RUNTIME_SUBCOMMANDS:
+        _run_runtime_cli(sys.argv[1], sys.argv[2:])
     else:
         arguably.run()

--- a/deq/deq/cli/simulate.py
+++ b/deq/deq/cli/simulate.py
@@ -317,6 +317,7 @@ def simulate__ler(
                     _run_batch,
                     bin_path=bin_path,
                     stim_path=stim_path,
+                    jit_path=jit_path,
                     batch_size=this_batch,
                     max_errors=remaining_errors,
                     decoder=decoder,
@@ -384,6 +385,7 @@ def simulate__ler(
 def _run_batch(
     bin_path: str,
     stim_path: str,
+    jit_path: str,
     batch_size: int,
     max_errors: int,
     decoder: str,
@@ -395,6 +397,17 @@ def _run_batch(
     simulator: str = "static",
 ) -> dict[str, int | float]:
     """Spawn one deq_runtime server process for a batch of shots."""
+    simulator_config: dict[str, object] = {
+        "filepath": stim_path,
+        "shots": batch_size,
+        "errors": max_errors,
+    }
+    if seed is not None:
+        simulator_config["seed"] = seed
+    if simulator == "jit-static":
+        # JitStaticSimulatorConfig requires the JIT library path on top
+        # of the common stim/shots/errors/seed fields.
+        simulator_config["jit_library_filepath"] = jit_path
     cmd = [
         sys.executable,
         "-m",
@@ -413,14 +426,7 @@ def _run_batch(
         "--simulator",
         simulator,
         "--simulator-config",
-        json.dumps(
-            {
-                "filepath": stim_path,
-                "shots": batch_size,
-                "errors": max_errors,
-                **({"seed": seed} if seed is not None else {}),
-            }
-        ),
+        json.dumps(simulator_config),
     ]
     if decoder_config is not None:
         cmd += ["--decoder-config", decoder_config]

--- a/deq/deq_runtime/Cargo.toml
+++ b/deq/deq_runtime/Cargo.toml
@@ -47,7 +47,7 @@ cli = [
     "tonic/channel",
     "tonic/router",
 ] # CLI binary, server, benchmark (not needed by library consumers)
-python = ["dep:pyo3", "dep:pythonize"] # enable Python decoder (requires Python)
+python = ["dep:pyo3"] # enable Python decoder (requires Python)
 python_binding = [
     "python",
     "pyo3/extension-module",
@@ -103,7 +103,6 @@ relay-bp = "0.2.2"
 ndarray = "=0.16.1"
 sprs = "=0.11.3"
 fastrace = { version = "0.7.14", features = ["enable"], optional = true }
-pythonize = { version = "0.27", optional = true }
 stim = { version = "0.4.1", optional = true }
 rhai = { version = "1", features = ["sync"], optional = true }
 cxx = { version = "1.0", optional = true }

--- a/deq/deq_runtime/Cargo.toml
+++ b/deq/deq_runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deq-runtime"
-version = "0.3.0"
+version = "0.3.2"
 edition = "2024"
 authors = ["Microsoft Corporation"]
 description = "deq: Real-time Quantum Error Correction Decoding System"

--- a/deq/deq_runtime/src/cli.rs
+++ b/deq/deq_runtime/src/cli.rs
@@ -55,7 +55,7 @@ enum Commands {
 enum TestCommands {
     /// Run the standard suite against a Python decoder defined in a *.py file
     PythonDecoder {
-        /// Path to the Python decoder file (must expose `new(...)` and a decoder with `decode(...)` / `reset()`)
+        /// Path to the Python decoder file (must expose a `Decoder` class with `__init__(hypergraph, config)`, `decode(...)`, `reset()`)
         #[clap(long)]
         file: PathBuf,
         /// Optional Python-decoder configuration as a JSON object

--- a/deq/deq_runtime/src/cli.rs
+++ b/deq/deq_runtime/src/cli.rs
@@ -1,8 +1,16 @@
 use crate::benchmark::BenchmarkCommands;
+#[cfg(feature = "python")]
+use crate::misc::parser::SerdeJsonParser;
 use crate::server::ServerConfigs;
 use clap::builder::styling;
+#[cfg(feature = "python")]
+use clap::builder::ValueParser;
 use clap::{Parser, Subcommand};
+#[cfg(feature = "python")]
+use serde_json::json;
 use std::env;
+#[cfg(feature = "python")]
+use std::path::PathBuf;
 
 #[derive(Parser, Clone)]
 #[clap(author = clap::crate_authors!(", "))]
@@ -34,6 +42,26 @@ enum Commands {
         #[clap(subcommand)]
         command: BenchmarkCommands,
     },
+    /// Run the standard decoder test suite against a user-provided decoder
+    #[cfg(feature = "python")]
+    Test {
+        #[clap(subcommand)]
+        command: TestCommands,
+    },
+}
+
+#[cfg(feature = "python")]
+#[derive(Subcommand, Clone)]
+enum TestCommands {
+    /// Run the standard suite against a Python decoder defined in a *.py file
+    PythonDecoder {
+        /// Path to the Python decoder file (must expose `new(...)` and a decoder with `decode(...)` / `reset()`)
+        #[clap(long)]
+        file: PathBuf,
+        /// Optional Python-decoder configuration as a JSON object
+        #[clap(long, default_value_t = json!({}), value_parser = ValueParser::new(SerdeJsonParser))]
+        py_config: serde_json::Value,
+    },
 }
 
 impl Cli {
@@ -45,7 +73,46 @@ impl Cli {
             Commands::Benchmark { command } => {
                 command.run().await;
             }
+            #[cfg(feature = "python")]
+            Commands::Test { command } => {
+                command.run().await;
+            }
         }
+    }
+}
+
+#[cfg(feature = "python")]
+impl TestCommands {
+    pub async fn run(self) {
+        match self {
+            TestCommands::PythonDecoder { file, py_config } => {
+                run_python_decoder_test(file, py_config).await;
+            }
+        }
+    }
+}
+
+#[cfg(feature = "python")]
+async fn run_python_decoder_test(file: PathBuf, py_config: serde_json::Value) {
+    use crate::decoder::test_harness::run_standard_suite;
+    use crate::decoder::{BlackBoxDecoderClient, DynBlackBoxDecoder, PythonDecoder};
+    use std::sync::Arc;
+
+    let config = serde_json::json!({
+        "file": file.to_string_lossy(),
+        "py_config": py_config,
+    });
+    let decoder = Arc::new(PythonDecoder::new(config));
+    let mut client = BlackBoxDecoderClient::Local(DynBlackBoxDecoder::BlackBoxPython(decoder));
+    let report = run_standard_suite(&mut client).await;
+    for line in report.summary_lines() {
+        println!("{line}");
+    }
+    let passed = report.pass_count();
+    let total = report.total();
+    println!("passed: {passed}/{total}");
+    if passed != total {
+        std::process::exit(1);
     }
 }
 

--- a/deq/deq_runtime/src/cli.rs
+++ b/deq/deq_runtime/src/cli.rs
@@ -2,9 +2,9 @@ use crate::benchmark::BenchmarkCommands;
 #[cfg(feature = "python")]
 use crate::misc::parser::SerdeJsonParser;
 use crate::server::ServerConfigs;
-use clap::builder::styling;
 #[cfg(feature = "python")]
 use clap::builder::ValueParser;
+use clap::builder::styling;
 use clap::{Parser, Subcommand};
 #[cfg(feature = "python")]
 use serde_json::json;

--- a/deq/deq_runtime/src/decoder.rs
+++ b/deq/deq_runtime/src/decoder.rs
@@ -59,6 +59,8 @@ pub mod blackbox_decoder {
 
 pub mod blackbox_util;
 pub mod mock_decoder;
+pub mod test_harness;
+pub mod test_problems;
 pub mod thread_pooling;
 
 pub mod naive_decoder;

--- a/deq/deq_runtime/src/decoder/naive_decoder.py
+++ b/deq/deq_runtime/src/decoder/naive_decoder.py
@@ -1,25 +1,20 @@
 from typing import Dict
 
 
-class NaiveDecoder:
-    def __init__(self, verbose: bool = False):
-        self.verbose = verbose
+class Decoder:
+    def __init__(self, hypergraph, config: Dict):
+        self.verbose = bool(config.get("verbose", False))
+        if self.verbose:
+            print("Creating Decoder")
+            print("    hypergraph:", hypergraph)
+            print("    config:", config)
 
     def decode(self, syndrome: list[int]) -> list[int]:
         assert isinstance(syndrome, list)
         if self.verbose:
-            print("Decoding with NaiveDecoder")
+            print("Decoding with Decoder")
         return []
 
     def reset(self):
         if self.verbose:
-            print("Resetting NaiveDecoder")
-
-
-def new(hypergraph, config: Dict) -> NaiveDecoder:
-    verbose = bool(config.get("verbose", False))
-    if verbose:
-        print("Creating NaiveDecoder")
-        print("    hypergraph:", hypergraph)
-        print("    config:", config)
-    return NaiveDecoder(verbose=verbose)
+            print("Resetting Decoder")

--- a/deq/deq_runtime/src/decoder/python_decoder.rs
+++ b/deq/deq_runtime/src/decoder/python_decoder.rs
@@ -2,9 +2,13 @@
 //!
 //! Calling another decoder written in Python language with the following APIs:
 //!
-//! fn new(hypergraph: &DecodingHypergraph, config: Dict | None) -> Decoder
-//! fn decode(self: Decoder, syndrome: list[int]) -> list[int]
-//! fn reset(self: Decoder) -> None
+//! class Decoder:
+//!     def __init__(self, hypergraph: DecodingHypergraph, config: Dict): ...
+//!     def decode(self, syndrome: list[int]) -> list[int]: ...
+//!     def reset(self) -> None: ...
+//!
+//! The class name defaults to `Decoder` and can be overridden by setting the
+//! top-level `name` field in the decoder JSON config.
 //!
 
 use crate::decoder::blackbox_decoder::{DecodingHypergraph, ParityFactor};
@@ -26,9 +30,16 @@ pub struct PythonDecoderConfig {
     pub thread_pooling_config: ThreadPoolingConfig,
     /// the entry file of the Python decoder (should be a file *.py)
     pub file: String,
+    /// the name of the decoder class inside the Python file; defaults to "Decoder"
+    #[serde(default = "default_decoder_class_name")]
+    pub name: String,
     /// Python decoder parameters
     #[structdoc(skip)]
     pub py_config: Option<serde_json::Value>,
+}
+
+fn default_decoder_class_name() -> String {
+    "Decoder".to_string()
 }
 
 #[pyclass(name = "DecodingHypergraph")]
@@ -97,7 +108,8 @@ impl DecoderInstance for PythonDecoderInstance {
             let module = get_or_load_module(py, &config.file)?;
             let py_hypergraph = PyDecodingHypergraph::new(py, hypergraph)?;
             let py_config = json_value_to_py(py, &config.py_config.unwrap_or_else(|| serde_json::json!({})))?;
-            let decoder = module.getattr("new")?.call1((py_hypergraph, py_config))?;
+            let decoder_class = module.getattr(config.name.as_str())?;
+            let decoder = decoder_class.call1((py_hypergraph, py_config))?;
             Ok::<Py<PyAny>, PyErr>(decoder.unbind())
         })
         .unwrap();
@@ -150,7 +162,7 @@ fn get_or_load_module<'py>(py: Python<'py>, file: &str) -> PyResult<Bound<'py, P
     // Note: register in sys.modules AFTER exec_module finishes. Heavy imports
     // (e.g. numpy / scipy) inside the loaded module release the GIL, which
     // would otherwise let another rayon worker thread observe a half-loaded
-    // module and call `getattr("new")` before `new` is defined.
+    // module and call `getattr` for the decoder class before it is defined.
     spec.getattr("loader")?.call_method1("exec_module", (module.clone(),))?;
     modules.set_item(&module_name, module.clone())?;
     Ok(module)

--- a/deq/deq_runtime/src/decoder/python_decoder.rs
+++ b/deq/deq_runtime/src/decoder/python_decoder.rs
@@ -12,8 +12,7 @@ use crate::decoder::thread_pooling::{DecoderInstance, ThreadPoolingConfig, Threa
 use crate::misc::bit_vector::to_sparse_indices;
 use crate::util::BitVector;
 use pyo3::prelude::*;
-use pyo3::types::PyList;
-use pythonize::pythonize;
+use pyo3::types::{PyDict, PyList};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "cli")]
 use structdoc::StructDoc;
@@ -97,7 +96,7 @@ impl DecoderInstance for PythonDecoderInstance {
         let decoder = Python::attach(|py| {
             let module = get_or_load_module(py, &config.file)?;
             let py_hypergraph = PyDecodingHypergraph::new(py, hypergraph)?;
-            let py_config = pythonize(py, &config.py_config.unwrap_or_else(|| serde_json::json!({}))).unwrap();
+            let py_config = json_value_to_py(py, &config.py_config.unwrap_or_else(|| serde_json::json!({})))?;
             let decoder = module.getattr("new")?.call1((py_hypergraph, py_config))?;
             Ok::<Py<PyAny>, PyErr>(decoder.unbind())
         })
@@ -132,17 +131,73 @@ impl DecoderInstance for PythonDecoderInstance {
 fn get_or_load_module<'py>(py: Python<'py>, file: &str) -> PyResult<Bound<'py, PyAny>> {
     // In principle, you should not need to modify sys.path; if you encounter some problem
     // with module loading, try `export LD_LIBRARY_PATH="$HOME/miniforge3/lib/:$LD_LIBRARY_PATH"`
+    //
+    // Use the file path as part of the module name so different Python decoder files
+    // loaded by the same process get distinct modules (otherwise the first-loaded file
+    // would be returned for every subsequent file).
+    let module_name = format!(
+        "deq_python_decoder_{}",
+        file.replace(|c: char| !c.is_ascii_alphanumeric(), "_")
+    );
     let sys = py.import("sys")?;
     let modules = sys.getattr("modules")?;
-    if modules.get_item("deq_python_decoder").is_ok() {
-        return modules.get_item("deq_python_decoder");
+    if let Ok(existing) = modules.get_item(&module_name) {
+        return Ok(existing);
     }
     let util = py.import("importlib.util")?;
-    let spec = util.call_method1("spec_from_file_location", ("deq_python_decoder", file))?;
+    let spec = util.call_method1("spec_from_file_location", (&module_name, file))?;
     let module = util.call_method1("module_from_spec", (spec.clone(),))?;
-    sys.getattr("modules")?.set_item("deq_python_decoder", module.clone())?;
+    // Note: register in sys.modules AFTER exec_module finishes. Heavy imports
+    // (e.g. numpy / scipy) inside the loaded module release the GIL, which
+    // would otherwise let another rayon worker thread observe a half-loaded
+    // module and call `getattr("new")` before `new` is defined.
     spec.getattr("loader")?.call_method1("exec_module", (module.clone(),))?;
+    modules.set_item(&module_name, module.clone())?;
     Ok(module)
+}
+
+/// Convert a [`serde_json::Value`] directly into a Python object.
+///
+/// We don't use the `pythonize` crate here because this crate enables
+/// `serde_json/arbitrary_precision`, under which `serde_json::Number` is
+/// serialized as the sentinel map `{"$serde_json::private::Number": "10"}`
+/// instead of a plain integer. That sentinel breaks any downstream Python
+/// callee that expects a real `int` or `float` (e.g. pybind11-bound C++
+/// constructors with strict type checks). Walking the `Value` tree manually
+/// lets us emit native Python scalars.
+fn json_value_to_py<'py>(py: Python<'py>, value: &serde_json::Value) -> PyResult<Bound<'py, PyAny>> {
+    match value {
+        serde_json::Value::Null => Ok(py.None().into_bound(py)),
+        serde_json::Value::Bool(b) => Ok(pyo3::types::PyBool::new(py, *b).to_owned().into_any()),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Ok(i.into_pyobject(py)?.into_any())
+            } else if let Some(u) = n.as_u64() {
+                Ok(u.into_pyobject(py)?.into_any())
+            } else if let Some(f) = n.as_f64() {
+                Ok(f.into_pyobject(py)?.into_any())
+            } else {
+                // Arbitrary-precision number that doesn't fit any of the above:
+                // fall back to a Python string so the callee can convert.
+                Ok(n.to_string().into_pyobject(py)?.into_any())
+            }
+        }
+        serde_json::Value::String(s) => Ok(s.into_pyobject(py)?.into_any()),
+        serde_json::Value::Array(items) => {
+            let list = PyList::empty(py);
+            for item in items {
+                list.append(json_value_to_py(py, item)?)?;
+            }
+            Ok(list.into_any())
+        }
+        serde_json::Value::Object(map) => {
+            let dict = PyDict::new(py);
+            for (key, val) in map {
+                dict.set_item(key, json_value_to_py(py, val)?)?;
+            }
+            Ok(dict.into_any())
+        }
+    }
 }
 
 pub type PythonDecoder = ThreadPoolingDecoder<PythonDecoderInstance>;

--- a/deq/deq_runtime/src/decoder/relay_bp_decoder.py
+++ b/deq/deq_runtime/src/decoder/relay_bp_decoder.py
@@ -1,0 +1,80 @@
+"""Python decoder wrapper around the public ``relay-bp`` PyPI package.
+
+Exposes the deq Python decoder protocol:
+
+    new(hypergraph, config: dict) -> RelayBPDecoder
+    RelayBPDecoder.decode(syndrome: list[int]) -> list[int]
+    RelayBPDecoder.reset() -> None
+
+Both ``syndrome`` and the returned subgraph are *sparse* index lists.
+
+The ``config`` dictionary is forwarded verbatim as keyword arguments to
+``relay_bp.RelayDecoderF64`` (see its docstring for supported keys, e.g.
+``alpha``, ``gamma0``, ``num_sets``, ``seed``, ``gamma_dist_interval``).
+Unknown keys raise ``TypeError`` from ``RelayDecoderF64`` itself.
+
+Test against the standard suite from the deq CLI (run from
+``deq/deq_runtime``)::
+
+    LD_LIBRARY_PATH="$(python -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))'):$LD_LIBRARY_PATH" \
+        cargo run --bin deq-runtime-cli --features python -- \
+        test python-decoder --file src/decoder/relay_bp_decoder.py
+
+The ``LD_LIBRARY_PATH`` shim points the embedded interpreter at a
+``libpython`` that has ``numpy``, ``scipy`` and ``relay_bp`` installed; omit
+it if your system Python already has them. Pass ``--py-config '{"seed": 42}'``
+to override decoder kwargs.
+"""
+
+from typing import Any, Dict, List
+
+import numpy as np
+from scipy.sparse import csr_matrix
+
+from relay_bp import RelayDecoderF64
+
+
+class RelayBPDecoder:
+    def __init__(self, vertex_num: int, num_hyperedges: int, solver: RelayDecoderF64):
+        self._vertex_num = vertex_num
+        self._num_hyperedges = num_hyperedges
+        self._solver = solver
+
+    def decode(self, syndrome: List[int]) -> List[int]:
+        assert isinstance(syndrome, list)
+        dense = np.zeros(self._vertex_num, dtype=np.uint8)
+        for index in syndrome:
+            dense[int(index)] = 1
+        result = self._solver.decode(dense)
+        return [int(i) for i in np.flatnonzero(np.asarray(result))]
+
+    def reset(self) -> None:
+        return None
+
+
+def new(hypergraph: Any, config: Dict[str, Any]) -> Any:
+    vertex_num = int(hypergraph.vertex_num)
+    hyperedges = list(hypergraph.hyperedges)
+    num_hyperedges = len(hyperedges)
+
+    rows: List[int] = []
+    cols: List[int] = []
+    error_priors = np.empty(num_hyperedges, dtype=np.float64)
+    for column, hyperedge in enumerate(hyperedges):
+        for vertex in hyperedge.vertices:
+            rows.append(int(vertex))
+            cols.append(column)
+        error_priors[column] = float(hyperedge.probability)
+
+    data = np.ones(len(rows), dtype=np.uint8)
+    check_matrix = csr_matrix(
+        (data, (rows, cols)),
+        shape=(vertex_num, num_hyperedges),
+    )
+
+    kwargs = dict(config or {})
+    if "gamma_dist_interval" in kwargs and isinstance(kwargs["gamma_dist_interval"], list):
+        kwargs["gamma_dist_interval"] = tuple(kwargs["gamma_dist_interval"])
+
+    solver = RelayDecoderF64(check_matrix, error_priors, **kwargs)
+    return RelayBPDecoder(vertex_num, num_hyperedges, solver)

--- a/deq/deq_runtime/src/decoder/relay_bp_decoder.py
+++ b/deq/deq_runtime/src/decoder/relay_bp_decoder.py
@@ -2,9 +2,10 @@
 
 Exposes the deq Python decoder protocol:
 
-    new(hypergraph, config: dict) -> RelayBPDecoder
-    RelayBPDecoder.decode(syndrome: list[int]) -> list[int]
-    RelayBPDecoder.reset() -> None
+    class Decoder:
+        def __init__(self, hypergraph, config: dict): ...
+        def decode(self, syndrome: list[int]) -> list[int]: ...
+        def reset(self) -> None: ...
 
 Both ``syndrome`` and the returned subgraph are *sparse* index lists.
 
@@ -34,11 +35,34 @@ from scipy.sparse import csr_matrix
 from relay_bp import RelayDecoderF64
 
 
-class RelayBPDecoder:
-    def __init__(self, vertex_num: int, num_hyperedges: int, solver: RelayDecoderF64):
+class Decoder:
+    def __init__(self, hypergraph: Any, config: Dict[str, Any]):
+        vertex_num = int(hypergraph.vertex_num)
+        hyperedges = list(hypergraph.hyperedges)
+        num_hyperedges = len(hyperedges)
+
+        rows: List[int] = []
+        cols: List[int] = []
+        error_priors = np.empty(num_hyperedges, dtype=np.float64)
+        for column, hyperedge in enumerate(hyperedges):
+            for vertex in hyperedge.vertices:
+                rows.append(int(vertex))
+                cols.append(column)
+            error_priors[column] = float(hyperedge.probability)
+
+        data = np.ones(len(rows), dtype=np.uint8)
+        check_matrix = csr_matrix(
+            (data, (rows, cols)),
+            shape=(vertex_num, num_hyperedges),
+        )
+
+        kwargs = dict(config or {})
+        if "gamma_dist_interval" in kwargs and isinstance(kwargs["gamma_dist_interval"], list):
+            kwargs["gamma_dist_interval"] = tuple(kwargs["gamma_dist_interval"])
+
         self._vertex_num = vertex_num
         self._num_hyperedges = num_hyperedges
-        self._solver = solver
+        self._solver = RelayDecoderF64(check_matrix, error_priors, **kwargs)
 
     def decode(self, syndrome: List[int]) -> List[int]:
         assert isinstance(syndrome, list)
@@ -50,31 +74,3 @@ class RelayBPDecoder:
 
     def reset(self) -> None:
         return None
-
-
-def new(hypergraph: Any, config: Dict[str, Any]) -> Any:
-    vertex_num = int(hypergraph.vertex_num)
-    hyperedges = list(hypergraph.hyperedges)
-    num_hyperedges = len(hyperedges)
-
-    rows: List[int] = []
-    cols: List[int] = []
-    error_priors = np.empty(num_hyperedges, dtype=np.float64)
-    for column, hyperedge in enumerate(hyperedges):
-        for vertex in hyperedge.vertices:
-            rows.append(int(vertex))
-            cols.append(column)
-        error_priors[column] = float(hyperedge.probability)
-
-    data = np.ones(len(rows), dtype=np.uint8)
-    check_matrix = csr_matrix(
-        (data, (rows, cols)),
-        shape=(vertex_num, num_hyperedges),
-    )
-
-    kwargs = dict(config or {})
-    if "gamma_dist_interval" in kwargs and isinstance(kwargs["gamma_dist_interval"], list):
-        kwargs["gamma_dist_interval"] = tuple(kwargs["gamma_dist_interval"])
-
-    solver = RelayDecoderF64(check_matrix, error_priors, **kwargs)
-    return RelayBPDecoder(vertex_num, num_hyperedges, solver)

--- a/deq/deq_runtime/src/decoder/tesseract_decoder.py
+++ b/deq/deq_runtime/src/decoder/tesseract_decoder.py
@@ -2,9 +2,10 @@
 
 Exposes the deq Python decoder protocol:
 
-    new(hypergraph, config: dict) -> TesseractDecoder
-    TesseractDecoder.decode(syndrome: list[int]) -> list[int]
-    TesseractDecoder.reset() -> None
+    class Decoder:
+        def __init__(self, hypergraph, config: dict): ...
+        def decode(self, syndrome: list[int]) -> list[int]: ...
+        def reset(self) -> None: ...
 
 Both ``syndrome`` and the returned subgraph are *sparse* index lists.
 
@@ -34,11 +35,27 @@ import stim
 from tesseract_decoder import tesseract
 
 
-class TesseractDecoder:
-    def __init__(self, vertex_num: int, num_hyperedges: int, solver: Any):
+def _build_dem(vertex_num: int, hyperedges) -> stim.DetectorErrorModel:
+    lines = []
+    for hyperedge in hyperedges:
+        detectors = " ".join(f"D{int(v)}" for v in hyperedge.vertices)
+        lines.append(f"error({float(hyperedge.probability)}) {detectors}")
+    text = "\n".join(lines) + "\n"
+    return stim.DetectorErrorModel(text)
+
+
+class Decoder:
+    def __init__(self, hypergraph: Any, config: Dict[str, Any]):
+        vertex_num = int(hypergraph.vertex_num)
+        hyperedges = list(hypergraph.hyperedges)
+        num_hyperedges = len(hyperedges)
+
+        dem = _build_dem(vertex_num, hyperedges)
+        kwargs = dict(config or {})
+
         self._vertex_num = vertex_num
         self._num_hyperedges = num_hyperedges
-        self._solver = solver
+        self._solver = tesseract.TesseractConfig(dem=dem, **kwargs).compile_decoder()
 
     def decode(self, syndrome: List[int]) -> List[int]:
         assert isinstance(syndrome, list)
@@ -50,23 +67,3 @@ class TesseractDecoder:
 
     def reset(self) -> None:
         return None
-
-
-def _build_dem(vertex_num: int, hyperedges) -> stim.DetectorErrorModel:
-    lines = []
-    for hyperedge in hyperedges:
-        detectors = " ".join(f"D{int(v)}" for v in hyperedge.vertices)
-        lines.append(f"error({float(hyperedge.probability)}) {detectors}")
-    text = "\n".join(lines) + "\n"
-    return stim.DetectorErrorModel(text)
-
-
-def new(hypergraph: Any, config: Dict[str, Any]) -> Any:
-    vertex_num = int(hypergraph.vertex_num)
-    hyperedges = list(hypergraph.hyperedges)
-    num_hyperedges = len(hyperedges)
-
-    dem = _build_dem(vertex_num, hyperedges)
-    kwargs = dict(config or {})
-    solver = tesseract.TesseractConfig(dem=dem, **kwargs).compile_decoder()
-    return TesseractDecoder(vertex_num, num_hyperedges, solver)

--- a/deq/deq_runtime/src/decoder/tesseract_decoder.py
+++ b/deq/deq_runtime/src/decoder/tesseract_decoder.py
@@ -1,0 +1,72 @@
+"""Python decoder wrapper around the public ``tesseract-decoder`` PyPI package.
+
+Exposes the deq Python decoder protocol:
+
+    new(hypergraph, config: dict) -> TesseractDecoder
+    TesseractDecoder.decode(syndrome: list[int]) -> list[int]
+    TesseractDecoder.reset() -> None
+
+Both ``syndrome`` and the returned subgraph are *sparse* index lists.
+
+The ``config`` dictionary is forwarded verbatim as keyword arguments to
+``tesseract_decoder.tesseract.TesseractConfig`` (see its docstring for
+supported keys, e.g. ``det_beam``, ``beam_climbing``, ``pqlimit``).
+Unknown keys raise ``TypeError`` from ``TesseractConfig`` itself.
+
+Test against the standard suite from the deq CLI (run from
+``deq/deq_runtime``)::
+
+    LD_LIBRARY_PATH="$(python -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))'):$LD_LIBRARY_PATH" \
+        cargo run --bin deq-runtime-cli --features python -- \
+        test python-decoder --file src/decoder/tesseract_decoder.py
+
+The ``LD_LIBRARY_PATH`` shim points the embedded interpreter at a
+``libpython`` that has ``numpy``, ``stim`` and ``tesseract_decoder``
+installed; omit it if your system Python already has them. Pass
+``--py-config '{"det_beam": 10}'`` to override decoder kwargs.
+"""
+
+from typing import Any, Dict, List
+
+import numpy as np
+import stim
+
+from tesseract_decoder import tesseract
+
+
+class TesseractDecoder:
+    def __init__(self, vertex_num: int, num_hyperedges: int, solver: Any):
+        self._vertex_num = vertex_num
+        self._num_hyperedges = num_hyperedges
+        self._solver = solver
+
+    def decode(self, syndrome: List[int]) -> List[int]:
+        assert isinstance(syndrome, list)
+        dense = np.zeros(self._vertex_num, dtype=bool)
+        for index in syndrome:
+            dense[int(index)] = True
+        self._solver.decode_to_errors(dense)
+        return [int(i) for i in self._solver.predicted_errors_buffer]
+
+    def reset(self) -> None:
+        return None
+
+
+def _build_dem(vertex_num: int, hyperedges) -> stim.DetectorErrorModel:
+    lines = []
+    for hyperedge in hyperedges:
+        detectors = " ".join(f"D{int(v)}" for v in hyperedge.vertices)
+        lines.append(f"error({float(hyperedge.probability)}) {detectors}")
+    text = "\n".join(lines) + "\n"
+    return stim.DetectorErrorModel(text)
+
+
+def new(hypergraph: Any, config: Dict[str, Any]) -> Any:
+    vertex_num = int(hypergraph.vertex_num)
+    hyperedges = list(hypergraph.hyperedges)
+    num_hyperedges = len(hyperedges)
+
+    dem = _build_dem(vertex_num, hyperedges)
+    kwargs = dict(config or {})
+    solver = tesseract.TesseractConfig(dem=dem, **kwargs).compile_decoder()
+    return TesseractDecoder(vertex_num, num_hyperedges, solver)

--- a/deq/deq_runtime/src/decoder/test_harness.rs
+++ b/deq/deq_runtime/src/decoder/test_harness.rs
@@ -1,0 +1,214 @@
+//! Standard decoder test harness
+//!
+//! Runs the curated set of [`StandardTestProblem`]s against any
+//! [`BlackBoxDecoderClient`] (local or remote), exercising both the one-shot
+//! `decode` path and the `load_hypergraph` + `decode_loaded` path for every
+//! case. Returns a [`SuiteReport`] describing the actual outcome of each call;
+//! callers decide what is acceptable.
+
+use crate::decoder::BlackBoxDecoderClient;
+use crate::decoder::blackbox_decoder::{self, DecodingHypergraph, ParityFactor};
+use crate::decoder::blackbox_util::is_parity_factor;
+use crate::decoder::test_problems::{StandardTestProblem, TestCase, case_id, standard_test_problems};
+use crate::util::BitVector;
+
+/// Which API path produced a [`CaseResult`].
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum Path {
+    /// One-shot `decode(hypergraph, syndrome)`.
+    Decode,
+    /// `load_hypergraph(hypergraph)` followed by `decode_loaded(hid, syndrome)`.
+    DecodeLoaded,
+}
+
+impl Path {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Path::Decode => "decode",
+            Path::DecodeLoaded => "decode_loaded",
+        }
+    }
+}
+
+/// Outcome of running one case on one API path.
+#[derive(Clone, Debug, PartialEq)]
+pub enum Outcome {
+    /// The decoder returned a subgraph that explains the syndrome.
+    Pass,
+    /// The decoder returned a subgraph that does not explain the syndrome.
+    InvalidSubgraph { returned: Vec<u64> },
+    /// The RPC failed (panic, error status, etc.).
+    RpcError(String),
+}
+
+impl Outcome {
+    pub fn is_pass(&self) -> bool {
+        matches!(self, Outcome::Pass)
+    }
+}
+
+/// Outcome of a single (problem, case, path) entry.
+#[derive(Clone, Debug)]
+pub struct CaseResult {
+    pub problem: &'static str,
+    pub case: &'static str,
+    pub path: Path,
+    pub outcome: Outcome,
+}
+
+/// Aggregated outcomes for one suite run.
+#[derive(Clone, Debug, Default)]
+pub struct SuiteReport {
+    pub results: Vec<CaseResult>,
+}
+
+impl SuiteReport {
+    /// Look up the outcome for a specific (problem, case, path) entry.
+    pub fn get(&self, problem: &str, case: &str, path: Path) -> Option<&Outcome> {
+        self.results
+            .iter()
+            .find(|r| r.problem == problem && r.case == case && r.path == path)
+            .map(|r| &r.outcome)
+    }
+
+    /// Number of entries that passed.
+    pub fn pass_count(&self) -> usize {
+        self.results.iter().filter(|r| r.outcome.is_pass()).count()
+    }
+
+    /// Total number of entries.
+    pub fn total(&self) -> usize {
+        self.results.len()
+    }
+
+    /// One human-readable line per entry, suitable for CLI output.
+    pub fn summary_lines(&self) -> Vec<String> {
+        self.results
+            .iter()
+            .map(|r| {
+                let id = case_id(r.problem, r.case);
+                match &r.outcome {
+                    Outcome::Pass => format!("[PASS] {}/{}", id, r.path.as_str()),
+                    Outcome::InvalidSubgraph { returned } => {
+                        format!("[FAIL] {}/{}  invalid subgraph: returned {:?}", id, r.path.as_str(), returned)
+                    }
+                    Outcome::RpcError(msg) => {
+                        format!("[FAIL] {}/{}  rpc error: {}", id, r.path.as_str(), msg)
+                    }
+                }
+            })
+            .collect()
+    }
+}
+
+fn classify(hypergraph: &DecodingHypergraph, syndrome: &BitVector, response: &ParityFactor) -> Outcome {
+    if is_parity_factor(hypergraph, response, syndrome) {
+        Outcome::Pass
+    } else {
+        Outcome::InvalidSubgraph {
+            returned: response.subgraph.clone(),
+        }
+    }
+}
+
+async fn run_one_problem(
+    client: &mut BlackBoxDecoderClient,
+    problem: &StandardTestProblem,
+    out: &mut Vec<CaseResult>,
+) {
+    for case in &problem.cases {
+        out.push(run_decode_path(client, problem, case).await);
+    }
+
+    let load_outcome = client.load_hypergraph(problem.hypergraph.clone()).await;
+    let hid = match load_outcome {
+        Ok(response) => Some(response.hid),
+        Err(status) => {
+            let msg = format!("load_hypergraph failed: {status}");
+            for case in &problem.cases {
+                out.push(CaseResult {
+                    problem: problem.name,
+                    case: case.name,
+                    path: Path::DecodeLoaded,
+                    outcome: Outcome::RpcError(msg.clone()),
+                });
+            }
+            None
+        }
+    };
+
+    if let Some(hid) = hid {
+        for case in &problem.cases {
+            out.push(run_decode_loaded_path(client, problem, case, hid).await);
+        }
+    }
+
+    // Best-effort reset between problems. Failures are recorded as a synthetic
+    // entry so callers see the issue but do not crash the rest of the suite.
+    if let Err(status) = client
+        .reset(blackbox_decoder::ResetRequest {
+            reset_hypergraphs: true,
+            ..Default::default()
+        })
+        .await
+    {
+        out.push(CaseResult {
+            problem: problem.name,
+            case: "reset",
+            path: Path::DecodeLoaded,
+            outcome: Outcome::RpcError(format!("reset failed: {status}")),
+        });
+    }
+}
+
+async fn run_decode_path(
+    client: &mut BlackBoxDecoderClient,
+    problem: &StandardTestProblem,
+    case: &TestCase,
+) -> CaseResult {
+    let problem_payload = blackbox_decoder::DecodingProblem {
+        hypergraph: Some(problem.hypergraph.clone()),
+        syndrome: Some(case.syndrome.clone()),
+    };
+    let outcome = match client.decode(problem_payload).await {
+        Ok(response) => classify(&problem.hypergraph, &case.syndrome, &response),
+        Err(status) => Outcome::RpcError(status.to_string()),
+    };
+    CaseResult {
+        problem: problem.name,
+        case: case.name,
+        path: Path::Decode,
+        outcome,
+    }
+}
+
+async fn run_decode_loaded_path(
+    client: &mut BlackBoxDecoderClient,
+    problem: &StandardTestProblem,
+    case: &TestCase,
+    hid: u64,
+) -> CaseResult {
+    let problem_payload = blackbox_decoder::LoadedDecodingProblem {
+        hid,
+        syndrome: Some(case.syndrome.clone()),
+    };
+    let outcome = match client.decode_loaded(problem_payload).await {
+        Ok(response) => classify(&problem.hypergraph, &case.syndrome, &response),
+        Err(status) => Outcome::RpcError(status.to_string()),
+    };
+    CaseResult {
+        problem: problem.name,
+        case: case.name,
+        path: Path::DecodeLoaded,
+        outcome,
+    }
+}
+
+/// Run the full standard suite against `client` and collect outcomes.
+pub async fn run_standard_suite(client: &mut BlackBoxDecoderClient) -> SuiteReport {
+    let mut results: Vec<CaseResult> = Vec::new();
+    for problem in standard_test_problems() {
+        run_one_problem(client, &problem, &mut results).await;
+    }
+    SuiteReport { results }
+}

--- a/deq/deq_runtime/src/decoder/test_harness.rs
+++ b/deq/deq_runtime/src/decoder/test_harness.rs
@@ -111,11 +111,7 @@ fn classify(hypergraph: &DecodingHypergraph, syndrome: &BitVector, response: &Pa
     }
 }
 
-async fn run_one_problem(
-    client: &mut BlackBoxDecoderClient,
-    problem: &StandardTestProblem,
-    out: &mut Vec<CaseResult>,
-) {
+async fn run_one_problem(client: &mut BlackBoxDecoderClient, problem: &StandardTestProblem, out: &mut Vec<CaseResult>) {
     for case in &problem.cases {
         out.push(run_decode_path(client, problem, case).await);
     }
@@ -161,11 +157,7 @@ async fn run_one_problem(
     }
 }
 
-async fn run_decode_path(
-    client: &mut BlackBoxDecoderClient,
-    problem: &StandardTestProblem,
-    case: &TestCase,
-) -> CaseResult {
+async fn run_decode_path(client: &mut BlackBoxDecoderClient, problem: &StandardTestProblem, case: &TestCase) -> CaseResult {
     let problem_payload = blackbox_decoder::DecodingProblem {
         hypergraph: Some(problem.hypergraph.clone()),
         syndrome: Some(case.syndrome.clone()),

--- a/deq/deq_runtime/src/decoder/test_problems.rs
+++ b/deq/deq_runtime/src/decoder/test_problems.rs
@@ -1,0 +1,143 @@
+//! Standard decoding test problems
+//!
+//! A small curated set of decoding problems used by the standard decoder test
+//! harness. The library carries **no policy** about which problems each decoder
+//! should solve correctly — that is up to each caller (integration tests, CLI)
+//! to specify.
+
+use crate::decoder::blackbox_decoder::{DecodingHypergraph, Hyperedge};
+use crate::misc::bit_vector::from_sparse_indices;
+use crate::util::BitVector;
+
+/// One standard test problem: a hypergraph plus a list of syndrome inputs.
+#[derive(Clone, Debug)]
+pub struct StandardTestProblem {
+    pub name: &'static str,
+    pub hypergraph: DecodingHypergraph,
+    pub cases: Vec<TestCase>,
+}
+
+/// A single syndrome input for a standard problem.
+#[derive(Clone, Debug)]
+pub struct TestCase {
+    pub name: &'static str,
+    pub syndrome: BitVector,
+}
+
+/// Format the identifier of a (problem, case) pair as `"problem/case"`.
+pub fn case_id(problem: &str, case: &str) -> String {
+    format!("{problem}/{case}")
+}
+
+fn edge(vertices: &[u64], probability: f64) -> Hyperedge {
+    Hyperedge {
+        vertices: vertices.to_vec(),
+        probability,
+    }
+}
+
+fn case(name: &'static str, vertex_num: u64, defect_indices: &[u64]) -> TestCase {
+    TestCase {
+        name,
+        syndrome: from_sparse_indices(vertex_num, defect_indices),
+    }
+}
+
+/// Return the standard list of decoding problems exercised by the harness.
+///
+/// The set is intentionally small and well-defined so every decoder can be
+/// reasoned about case-by-case.
+pub fn standard_test_problems() -> Vec<StandardTestProblem> {
+    vec![
+        StandardTestProblem {
+            name: "empty_graph",
+            hypergraph: DecodingHypergraph {
+                vertex_num: 0,
+                hyperedges: vec![],
+            },
+            cases: vec![case("zero", 0, &[])],
+        },
+        StandardTestProblem {
+            name: "no_edges",
+            hypergraph: DecodingHypergraph {
+                vertex_num: 3,
+                hyperedges: vec![],
+            },
+            cases: vec![case("zero", 3, &[])],
+        },
+        StandardTestProblem {
+            name: "single_vertex_boundary",
+            hypergraph: DecodingHypergraph {
+                vertex_num: 1,
+                hyperedges: vec![edge(&[0], 0.1)],
+            },
+            cases: vec![case("zero", 1, &[]), case("vertex_0", 1, &[0])],
+        },
+        StandardTestProblem {
+            name: "simple_edge",
+            hypergraph: DecodingHypergraph {
+                vertex_num: 2,
+                hyperedges: vec![edge(&[0, 1], 0.1)],
+            },
+            cases: vec![case("zero", 2, &[]), case("both", 2, &[0, 1])],
+        },
+        StandardTestProblem {
+            name: "single_hyperedge_3",
+            hypergraph: DecodingHypergraph {
+                vertex_num: 3,
+                hyperedges: vec![edge(&[0, 1, 2], 0.1)],
+            },
+            cases: vec![case("zero", 3, &[]), case("all", 3, &[0, 1, 2])],
+        },
+        StandardTestProblem {
+            name: "line_chain_3",
+            hypergraph: DecodingHypergraph {
+                vertex_num: 3,
+                hyperedges: vec![edge(&[0, 1], 0.1), edge(&[1, 2], 0.1)],
+            },
+            cases: vec![
+                case("zero", 3, &[]),
+                case("left", 3, &[0, 1]),
+                case("right", 3, &[1, 2]),
+                case("ends", 3, &[0, 2]),
+            ],
+        },
+        StandardTestProblem {
+            name: "triangle",
+            hypergraph: DecodingHypergraph {
+                vertex_num: 3,
+                hyperedges: vec![edge(&[0, 1], 0.1), edge(&[1, 2], 0.1), edge(&[0, 2], 0.1)],
+            },
+            cases: vec![
+                case("zero", 3, &[]),
+                case("v01", 3, &[0, 1]),
+                case("v12", 3, &[1, 2]),
+                case("v02", 3, &[0, 2]),
+            ],
+        },
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn problems_are_well_formed() {
+        for problem in standard_test_problems() {
+            assert!(!problem.cases.is_empty(), "problem {} has no cases", problem.name);
+            for case in &problem.cases {
+                assert_eq!(
+                    case.syndrome.size, problem.hypergraph.vertex_num,
+                    "case {}/{} syndrome size mismatch",
+                    problem.name, case.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn case_id_formats_as_problem_slash_case() {
+        assert_eq!(case_id("simple_edge", "both"), "simple_edge/both");
+    }
+}

--- a/deq/deq_runtime/tests/standard_decoder_test.rs
+++ b/deq/deq_runtime/tests/standard_decoder_test.rs
@@ -114,10 +114,7 @@ async fn test_tesseract_decoder() {
 #[tokio::test]
 async fn test_python_naive_decoder() {
     use deq_runtime::decoder::PythonDecoder;
-    let file = format!(
-        "{}/src/decoder/naive_decoder.py",
-        env!("CARGO_MANIFEST_DIR"),
-    );
+    let file = format!("{}/src/decoder/naive_decoder.py", env!("CARGO_MANIFEST_DIR"),);
     let config = serde_json::json!({ "file": file });
     let decoder = Arc::new(PythonDecoder::new(config));
     let mut client = BlackBoxDecoderClient::Local(DynBlackBoxDecoder::BlackBoxPython(decoder));
@@ -155,16 +152,10 @@ fn python_modules_available(test_name: &str, modules: &[&str]) -> bool {
 #[tokio::test]
 async fn test_python_relay_bp_decoder() {
     use deq_runtime::decoder::PythonDecoder;
-    if !python_modules_available(
-        "test_python_relay_bp_decoder",
-        &["numpy", "scipy.sparse", "relay_bp"],
-    ) {
+    if !python_modules_available("test_python_relay_bp_decoder", &["numpy", "scipy.sparse", "relay_bp"]) {
         return;
     }
-    let file = format!(
-        "{}/src/decoder/relay_bp_decoder.py",
-        env!("CARGO_MANIFEST_DIR"),
-    );
+    let file = format!("{}/src/decoder/relay_bp_decoder.py", env!("CARGO_MANIFEST_DIR"),);
     let config = serde_json::json!({ "file": file });
     let decoder = Arc::new(PythonDecoder::new(config));
     let mut client = BlackBoxDecoderClient::Local(DynBlackBoxDecoder::BlackBoxPython(decoder));
@@ -177,16 +168,10 @@ async fn test_python_relay_bp_decoder() {
 #[tokio::test]
 async fn test_python_tesseract_decoder() {
     use deq_runtime::decoder::PythonDecoder;
-    if !python_modules_available(
-        "test_python_tesseract_decoder",
-        &["numpy", "stim", "tesseract_decoder"],
-    ) {
+    if !python_modules_available("test_python_tesseract_decoder", &["numpy", "stim", "tesseract_decoder"]) {
         return;
     }
-    let file = format!(
-        "{}/src/decoder/tesseract_decoder.py",
-        env!("CARGO_MANIFEST_DIR"),
-    );
+    let file = format!("{}/src/decoder/tesseract_decoder.py", env!("CARGO_MANIFEST_DIR"),);
     let config = serde_json::json!({ "file": file });
     let decoder = Arc::new(PythonDecoder::new(config));
     let mut client = BlackBoxDecoderClient::Local(DynBlackBoxDecoder::BlackBoxPython(decoder));

--- a/deq/deq_runtime/tests/standard_decoder_test.rs
+++ b/deq/deq_runtime/tests/standard_decoder_test.rs
@@ -1,0 +1,196 @@
+//! Integration tests for the standard decoder test suite.
+//!
+//! Each decoder is exercised with a closure declaring the expected pass/fail
+//! outcome for every (problem, case, path) entry. The closure is the *test's*
+//! policy — the `test_problems` and `test_harness` modules do not assume
+//! anything about which cases should pass.
+
+use std::sync::Arc;
+
+use deq_runtime::decoder::test_harness::{Outcome, Path, SuiteReport, run_standard_suite};
+use deq_runtime::decoder::test_problems::standard_test_problems;
+use deq_runtime::decoder::{BlackBoxDecoderClient, DynBlackBoxDecoder, MockDecoder, NaiveDecoder};
+
+type ExpectedPassFn = fn(problem: &str, case: &str, path: Path) -> bool;
+
+/// Compare a [`SuiteReport`] against an expected-pass policy. Panics with a
+/// readable summary on any discrepancy.
+fn assert_matches_policy(report: &SuiteReport, expected_pass: ExpectedPassFn) {
+    let mut mismatches: Vec<String> = Vec::new();
+    for result in &report.results {
+        let expected = expected_pass(result.problem, result.case, result.path);
+        let actual = result.outcome.is_pass();
+        if expected != actual {
+            let detail = match &result.outcome {
+                Outcome::Pass => "Pass".to_string(),
+                Outcome::InvalidSubgraph { returned } => format!("InvalidSubgraph(returned={returned:?})"),
+                Outcome::RpcError(msg) => format!("RpcError({msg})"),
+            };
+            mismatches.push(format!(
+                "  {}/{}/{}: expected {}, got {}",
+                result.problem,
+                result.case,
+                result.path.as_str(),
+                if expected { "Pass" } else { "Fail" },
+                detail,
+            ));
+        }
+    }
+    assert!(
+        mismatches.is_empty(),
+        "decoder outcome did not match expectations:\n{}",
+        mismatches.join("\n"),
+    );
+}
+
+/// Every standard case must appear in the report exactly once per API path.
+fn assert_full_coverage(report: &SuiteReport) {
+    for problem in standard_test_problems() {
+        for case in &problem.cases {
+            for path in [Path::Decode, Path::DecodeLoaded] {
+                assert!(
+                    report.get(problem.name, case.name, path).is_some(),
+                    "missing entry for {}/{}/{}",
+                    problem.name,
+                    case.name,
+                    path.as_str(),
+                );
+            }
+        }
+    }
+}
+
+/// Policy shared by decoders that always return an empty subgraph:
+/// only the zero-syndrome cases satisfy the parity-factor check.
+fn always_empty_subgraph_policy(_problem: &str, case: &str, _path: Path) -> bool {
+    case == "zero"
+}
+
+/// Policy for real decoders that should solve every standard problem.
+fn always_pass_policy(_problem: &str, _case: &str, _path: Path) -> bool {
+    true
+}
+
+#[tokio::test]
+async fn test_naive_decoder() {
+    let decoder = Arc::new(NaiveDecoder::new(serde_json::json!({})));
+    let mut client = BlackBoxDecoderClient::Local(DynBlackBoxDecoder::BlackBoxNaive(decoder));
+    let report = run_standard_suite(&mut client).await;
+    assert_full_coverage(&report);
+    assert_matches_policy(&report, always_empty_subgraph_policy);
+}
+
+#[tokio::test]
+async fn test_mock_decoder() {
+    let decoder = Arc::new(MockDecoder::new());
+    let mut client = BlackBoxDecoderClient::Local(DynBlackBoxDecoder::MockDecoder(decoder));
+    let report = run_standard_suite(&mut client).await;
+    assert_full_coverage(&report);
+    assert_matches_policy(&report, always_empty_subgraph_policy);
+}
+
+#[tokio::test]
+async fn test_relay_bp_decoder() {
+    use deq_runtime::decoder::RelayBPDecoder;
+    let decoder = Arc::new(RelayBPDecoder::new(serde_json::json!({})));
+    let mut client = BlackBoxDecoderClient::Local(DynBlackBoxDecoder::BlackBoxRelayBP(decoder));
+    let report = run_standard_suite(&mut client).await;
+    assert_full_coverage(&report);
+    assert_matches_policy(&report, always_pass_policy);
+}
+
+#[cfg(feature = "tesseract")]
+#[tokio::test]
+async fn test_tesseract_decoder() {
+    use deq_runtime::decoder::TesseractDecoder;
+    let decoder = Arc::new(TesseractDecoder::new(serde_json::json!({})));
+    let mut client = BlackBoxDecoderClient::Local(DynBlackBoxDecoder::BlackBoxTesseract(decoder));
+    let report = run_standard_suite(&mut client).await;
+    assert_full_coverage(&report);
+    assert_matches_policy(&report, always_pass_policy);
+}
+
+#[cfg(feature = "python")]
+#[tokio::test]
+async fn test_python_naive_decoder() {
+    use deq_runtime::decoder::PythonDecoder;
+    let file = format!(
+        "{}/src/decoder/naive_decoder.py",
+        env!("CARGO_MANIFEST_DIR"),
+    );
+    let config = serde_json::json!({ "file": file });
+    let decoder = Arc::new(PythonDecoder::new(config));
+    let mut client = BlackBoxDecoderClient::Local(DynBlackBoxDecoder::BlackBoxPython(decoder));
+    let report = run_standard_suite(&mut client).await;
+    assert_full_coverage(&report);
+    assert_matches_policy(&report, always_empty_subgraph_policy);
+}
+
+/// Skip the test (with an explanatory message) when one of the listed Python
+/// modules is not importable in the embedded interpreter. Returns `true` when
+/// every module is available.
+#[cfg(feature = "python")]
+fn python_modules_available(test_name: &str, modules: &[&str]) -> bool {
+    use pyo3::Python;
+    let missing = Python::attach(|py| {
+        modules
+            .iter()
+            .filter(|name| py.import(**name).is_err())
+            .copied()
+            .map(String::from)
+            .collect::<Vec<_>>()
+    });
+    if !missing.is_empty() {
+        eprintln!(
+            "{test_name}: skipping — required Python module(s) not importable in embedded interpreter: {missing:?}. \
+             Hint: install the packages where the embedded libpython can find them, or run with \
+             `LD_LIBRARY_PATH=<conda-env>/lib` to load a libpython that has them."
+        );
+        return false;
+    }
+    true
+}
+
+#[cfg(feature = "python")]
+#[tokio::test]
+async fn test_python_relay_bp_decoder() {
+    use deq_runtime::decoder::PythonDecoder;
+    if !python_modules_available(
+        "test_python_relay_bp_decoder",
+        &["numpy", "scipy.sparse", "relay_bp"],
+    ) {
+        return;
+    }
+    let file = format!(
+        "{}/src/decoder/relay_bp_decoder.py",
+        env!("CARGO_MANIFEST_DIR"),
+    );
+    let config = serde_json::json!({ "file": file });
+    let decoder = Arc::new(PythonDecoder::new(config));
+    let mut client = BlackBoxDecoderClient::Local(DynBlackBoxDecoder::BlackBoxPython(decoder));
+    let report = run_standard_suite(&mut client).await;
+    assert_full_coverage(&report);
+    assert_matches_policy(&report, always_pass_policy);
+}
+
+#[cfg(feature = "python")]
+#[tokio::test]
+async fn test_python_tesseract_decoder() {
+    use deq_runtime::decoder::PythonDecoder;
+    if !python_modules_available(
+        "test_python_tesseract_decoder",
+        &["numpy", "stim", "tesseract_decoder"],
+    ) {
+        return;
+    }
+    let file = format!(
+        "{}/src/decoder/tesseract_decoder.py",
+        env!("CARGO_MANIFEST_DIR"),
+    );
+    let config = serde_json::json!({ "file": file });
+    let decoder = Arc::new(PythonDecoder::new(config));
+    let mut client = BlackBoxDecoderClient::Local(DynBlackBoxDecoder::BlackBoxPython(decoder));
+    let report = run_standard_suite(&mut client).await;
+    assert_full_coverage(&report);
+    assert_matches_policy(&report, always_pass_policy);
+}

--- a/deq/documents/tutorial/README.md
+++ b/deq/documents/tutorial/README.md
@@ -80,6 +80,7 @@ For example, if you want to evaluate the logical error rate performance, just wr
 # generate small_example.deq.jit and small_example.stim
 deq transpile small_example_evaluation.deq --out small_example.deq.jit --program Simulation
 # run logical error rate simulation from these files
+# NOTE: on Windows (cmd/PowerShell), escape inner double quotes, e.g. '{\"buffer_radius\":3}' instead of '{"buffer_radius":3}'
 deq server \
     --decoder black-box-relay-bp \
     --coordinator window \
@@ -115,6 +116,7 @@ Once you become comfortable with the basics, let's look at some advanced topics:
   - [Logical operation with multiple inputs and outputs](chapters/multi-port-gadgets.md)
   - [Floquet codes and dynamically generated logical qubits](chapters/floquet-code.md)
 - [Parametrization with Mako](chapters/mako-parametrization.md)
+- [Plug in your own decoder in Python](chapters/python-decoder.md)
 - [Debugging your .deq program](chapters/debug-deq-program.md)
 - [Steane-style syndrome extraction](chapters/steane-style-ec.md)
 - [Speed-accuracy trade-off with .deq program]

--- a/deq/documents/tutorial/chapters/python-decoder.md
+++ b/deq/documents/tutorial/chapters/python-decoder.md
@@ -39,29 +39,33 @@ overhead and a JSON round-trip for the per-decoder config.
 
 ## The Python decoder protocol
 
-A Python decoder file is any `*.py` file that exposes three things:
+A Python decoder file is any `*.py` file that exposes a single class:
 
 ```python
-def new(hypergraph, config: dict) -> Decoder: ...
-
 class Decoder:
+    def __init__(self, hypergraph, config: dict): ...
     def decode(self, syndrome: list[int]) -> list[int]: ...
     def reset(self) -> None: ...
 ```
 
-The runtime calls `new(...)` once per hypergraph and then `decode(...)` /
-`reset()` repeatedly. State that should persist across shots lives on the
-`Decoder` instance; state that should *not* persist across shots is what
-`reset()` clears.
+The runtime instantiates `Decoder(hypergraph, config)` once per hypergraph and
+then calls `decode(...)` / `reset()` repeatedly. State that should persist
+across shots lives on the instance; state that should *not* persist across
+shots is what `reset()` clears.
+
+The class name defaults to `Decoder`. If your file already uses a different
+name (or you want to expose several decoder classes from the same file), set
+the top-level `name` field in the decoder JSON config to override it — see
+[the config table below](#end-to-end-logical-error-rate-on-a-dynamic-circuit).
 
 **Inputs:**
 
-| Argument                  | Type                                  | Meaning                                                                 |
-| ------------------------- | ------------------------------------- | ----------------------------------------------------------------------- |
-| `hypergraph.vertex_num`   | `int`                                 | Number of detectors (hypergraph vertices).                              |
-| `hypergraph.hyperedges`   | `list[Hyperedge]`                     | Each hyperedge has `.vertices: list[int]` and `.probability: float`.    |
-| `config`                  | `dict`                                | Whatever JSON object you passed via `--py-config` (or `{}` if omitted). |
-| `syndrome` (to `decode`)  | `list[int]`                           | **Sparse** list of detector indices that fired.                         |
+| Argument                       | Type                                  | Meaning                                                                 |
+| ------------------------------ | ------------------------------------- | ----------------------------------------------------------------------- |
+| `hypergraph.vertex_num`        | `int`                                 | Number of detectors (hypergraph vertices).                              |
+| `hypergraph.hyperedges`        | `list[Hyperedge]`                     | Each hyperedge has `.vertices: list[int]` and `.probability: float`.    |
+| `config` (to `__init__`)       | `dict`                                | Whatever JSON object you passed via `--py-config` (or `{}` if omitted). |
+| `syndrome` (to `decode`)       | `list[int]`                           | **Sparse** list of detector indices that fired.                         |
 
 **Output of `decode`:** a **sparse** list of hyperedge indices forming the
 predicted fault subgraph. Returning `[]` means "no errors".
@@ -84,11 +88,33 @@ import numpy as np
 from scipy.sparse import csr_matrix
 from relay_bp import RelayDecoderF64
 
-class RelayBPDecoder:
-    def __init__(self, vertex_num, num_hyperedges, solver):
+class Decoder:
+    def __init__(self, hypergraph, config):
+        vertex_num = int(hypergraph.vertex_num)
+        hyperedges = list(hypergraph.hyperedges)
+        num_hyperedges = len(hyperedges)
+
+        rows, cols = [], []
+        error_priors = np.empty(num_hyperedges, dtype=np.float64)
+        for column, hyperedge in enumerate(hyperedges):
+            for vertex in hyperedge.vertices:
+                rows.append(int(vertex))
+                cols.append(column)
+            error_priors[column] = float(hyperedge.probability)
+
+        data = np.ones(len(rows), dtype=np.uint8)
+        check_matrix = csr_matrix(
+            (data, (rows, cols)),
+            shape=(vertex_num, num_hyperedges),
+        )
+
+        kwargs = dict(config or {})
+        if "gamma_dist_interval" in kwargs and isinstance(kwargs["gamma_dist_interval"], list):
+            kwargs["gamma_dist_interval"] = tuple(kwargs["gamma_dist_interval"])
+
         self._vertex_num = vertex_num
         self._num_hyperedges = num_hyperedges
-        self._solver = solver
+        self._solver = RelayDecoderF64(check_matrix, error_priors, **kwargs)
 
     def decode(self, syndrome):
         dense = np.zeros(self._vertex_num, dtype=np.uint8)
@@ -101,41 +127,11 @@ class RelayBPDecoder:
         return None
 ```
 
-`decode` does three things: sparse → dense conversion of the syndrome, BP
-inference, and dense → sparse conversion of the result. `RelayDecoderF64` keeps
-no per-shot state, so `reset()` is a no-op.
+`__init__` translates the hypergraph into a `csr_matrix` and constructs the
+underlying solver. `decode` does three things: sparse → dense conversion of the
+syndrome, BP inference, and dense → sparse conversion of the result.
+`RelayDecoderF64` keeps no per-shot state, so `reset()` is a no-op.
 
-### The `new` factory
-
-```python
-def new(hypergraph, config):
-    vertex_num = int(hypergraph.vertex_num)
-    hyperedges = list(hypergraph.hyperedges)
-    num_hyperedges = len(hyperedges)
-
-    rows, cols = [], []
-    error_priors = np.empty(num_hyperedges, dtype=np.float64)
-    for column, hyperedge in enumerate(hyperedges):
-        for vertex in hyperedge.vertices:
-            rows.append(int(vertex))
-            cols.append(column)
-        error_priors[column] = float(hyperedge.probability)
-
-    data = np.ones(len(rows), dtype=np.uint8)
-    check_matrix = csr_matrix(
-        (data, (rows, cols)),
-        shape=(vertex_num, num_hyperedges),
-    )
-
-    kwargs = dict(config or {})
-    if "gamma_dist_interval" in kwargs and isinstance(kwargs["gamma_dist_interval"], list):
-        kwargs["gamma_dist_interval"] = tuple(kwargs["gamma_dist_interval"])
-
-    solver = RelayDecoderF64(check_matrix, error_priors, **kwargs)
-    return RelayBPDecoder(vertex_num, num_hyperedges, solver)
-```
-
-This is just hypergraph-to-`csr_matrix` translation plus a constructor call.
 Two things worth pointing out:
 
 - **`config` is forwarded verbatim** to `RelayDecoderF64`. Unknown keys raise
@@ -146,7 +142,7 @@ Two things worth pointing out:
   would hit a type error they couldn't fix from the CLI.
 
 That's the whole wrapper. The same shape applies to any decoder: implement
-`decode`/`reset` on a class, and have `new` build it from the hypergraph.
+`__init__`/`decode`/`reset` on a class named `Decoder`.
 
 > An analogous wrapper for Google's Tesseract beam-search decoder lives at
 > [deq_runtime/src/decoder/tesseract_decoder.py](../../../deq_runtime/src/decoder/tesseract_decoder.py).
@@ -174,7 +170,7 @@ Two things to notice:
   you see `Error: deq_runtime is not installed`, rebuild the bindings with
   `cd deq_runtime && maturin develop --release --features python_all`.
 - **`--py-config '{...}'`** is optional. It is a JSON object that lands as the
-  `config` argument to your `new`. For example, to pin BP's RNG:
+  `config` argument to your `Decoder.__init__`. For example, to pin BP's RNG:
 
   ```sh
   deq test python-decoder \
@@ -229,11 +225,12 @@ deq server \
 
 `black-box-python` accepts the following config:
 
-| Field        | Type           | Meaning                                                                                                |
-| ------------ | -------------- | ------------------------------------------------------------------------------------------------------ |
-| `file`       | string         | Absolute or relative path to your `*.py` file. Must expose `new` plus a `decode`/`reset`-shaped class. |
-| `py_config`  | any JSON value | Forwarded to your `new` as the `config` argument. Omit for `{}`.                                       |
-| `parallel`   | int (optional) | Number of decoder worker threads (inherited from the thread-pooling layer).                            |
+| Field        | Type           | Meaning                                                                                                                |
+| ------------ | -------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `file`       | string         | Absolute or relative path to your `*.py` file. Must expose a class shaped like the [protocol above](#the-python-decoder-protocol). |
+| `name`       | string         | Optional. Name of the decoder class inside the file. Defaults to `"Decoder"`.                                          |
+| `py_config`  | any JSON value | Forwarded to your `Decoder.__init__` as the `config` argument. Omit for `{}`.                                          |
+| `parallel`   | int (optional) | Number of decoder worker threads (inherited from the thread-pooling layer).                                            |
 
 Pass `py_config` exactly the way you would pass `--py-config` to
 `test python-decoder`, just nested one level inside the decoder config:
@@ -242,6 +239,17 @@ Pass `py_config` exactly the way you would pass `--py-config` to
 --decoder-config '{
     "file": "deq_runtime/src/decoder/relay_bp_decoder.py",
     "py_config": {"seed": 42, "num_sets": 100}
+}'
+```
+
+If your file exposes its decoder under a different class name (or you want to
+pick one of several classes in the same file), set `name`:
+
+```sh
+--decoder-config '{
+    "file": "my_decoders.py",
+    "name": "MyCustomDecoder",
+    "py_config": {"seed": 42}
 }'
 ```
 

--- a/deq/documents/tutorial/chapters/python-decoder.md
+++ b/deq/documents/tutorial/chapters/python-decoder.md
@@ -1,0 +1,265 @@
+# Plug in your own decoder in Python
+
+deq's decoding system is **decoder-agnostic**. Anything that consumes a decoding
+hypergraph + syndrome and returns a fault subgraph (the "black-box" decoder
+contract) plugs in equally well. This chapter shows how to write that wrapper in
+**pure Python**, so you can take a decoder you have already prototyped — or a
+third-party package — and drop it straight into deq's dynamic-logical-circuit
+machinery without touching any Rust code.
+
+We will walk through:
+
+1. The Python decoder protocol — three functions, no inheritance.
+2. A worked example wrapping the public [`relay-bp`](https://pypi.org/project/relay-bp/) PyPI package in ~60 lines.
+3. Running the standard decoder unit-test suite against it.
+4. Driving a full logical error rate simulation with the wrapper as the decoder,
+   re-using the very same `small_example_evaluation.deq` from the intro chapter.
+
+---
+
+## When to reach for the Python bridge
+
+deq ships built-in `BlackBox*` decoders written directly in Rust (e.g.
+`black-box-relay-bp`, `black-box-tesseract`). Those are the right choice in
+production: each `decode()` call stays inside one process and avoids the GIL.
+
+The Python bridge is the right choice when:
+
+- You're **prototyping** a new decoder and want fast iteration.
+- The decoder you want to use only exists as a Python package (e.g. a research
+  prototype on PyPI, or a Jupyter-notebook-grown algorithm).
+- You're benchmarking several candidate decoders against the **same** dynamic
+  logical circuit before committing to a Rust port.
+
+The bridge is feature-complete — every coordinator, controller, and simulator
+deq supports works unchanged. The only differences are GIL-bound per-call
+overhead and a JSON round-trip for the per-decoder config.
+
+---
+
+## The Python decoder protocol
+
+A Python decoder file is any `*.py` file that exposes three things:
+
+```python
+def new(hypergraph, config: dict) -> Decoder: ...
+
+class Decoder:
+    def decode(self, syndrome: list[int]) -> list[int]: ...
+    def reset(self) -> None: ...
+```
+
+The runtime calls `new(...)` once per hypergraph and then `decode(...)` /
+`reset()` repeatedly. State that should persist across shots lives on the
+`Decoder` instance; state that should *not* persist across shots is what
+`reset()` clears.
+
+**Inputs:**
+
+| Argument                  | Type                                  | Meaning                                                                 |
+| ------------------------- | ------------------------------------- | ----------------------------------------------------------------------- |
+| `hypergraph.vertex_num`   | `int`                                 | Number of detectors (hypergraph vertices).                              |
+| `hypergraph.hyperedges`   | `list[Hyperedge]`                     | Each hyperedge has `.vertices: list[int]` and `.probability: float`.    |
+| `config`                  | `dict`                                | Whatever JSON object you passed via `--py-config` (or `{}` if omitted). |
+| `syndrome` (to `decode`)  | `list[int]`                           | **Sparse** list of detector indices that fired.                         |
+
+**Output of `decode`:** a **sparse** list of hyperedge indices forming the
+predicted fault subgraph. Returning `[]` means "no errors".
+
+That's the entire contract. There is no base class to inherit, no module-level
+registration, no metaclass magic.
+
+---
+
+## Worked example: wrapping `relay-bp`
+
+The runtime ships a working wrapper at
+[deq_runtime/src/decoder/relay_bp_decoder.py](../../../deq_runtime/src/decoder/relay_bp_decoder.py).
+It is ~60 lines and uses zero Rust. Let's walk through it.
+
+### The decoder class
+
+```python
+import numpy as np
+from scipy.sparse import csr_matrix
+from relay_bp import RelayDecoderF64
+
+class RelayBPDecoder:
+    def __init__(self, vertex_num, num_hyperedges, solver):
+        self._vertex_num = vertex_num
+        self._num_hyperedges = num_hyperedges
+        self._solver = solver
+
+    def decode(self, syndrome):
+        dense = np.zeros(self._vertex_num, dtype=np.uint8)
+        for index in syndrome:
+            dense[int(index)] = 1
+        result = self._solver.decode(dense)
+        return [int(i) for i in np.flatnonzero(np.asarray(result))]
+
+    def reset(self):
+        return None
+```
+
+`decode` does three things: sparse → dense conversion of the syndrome, BP
+inference, and dense → sparse conversion of the result. `RelayDecoderF64` keeps
+no per-shot state, so `reset()` is a no-op.
+
+### The `new` factory
+
+```python
+def new(hypergraph, config):
+    vertex_num = int(hypergraph.vertex_num)
+    hyperedges = list(hypergraph.hyperedges)
+    num_hyperedges = len(hyperedges)
+
+    rows, cols = [], []
+    error_priors = np.empty(num_hyperedges, dtype=np.float64)
+    for column, hyperedge in enumerate(hyperedges):
+        for vertex in hyperedge.vertices:
+            rows.append(int(vertex))
+            cols.append(column)
+        error_priors[column] = float(hyperedge.probability)
+
+    data = np.ones(len(rows), dtype=np.uint8)
+    check_matrix = csr_matrix(
+        (data, (rows, cols)),
+        shape=(vertex_num, num_hyperedges),
+    )
+
+    kwargs = dict(config or {})
+    if "gamma_dist_interval" in kwargs and isinstance(kwargs["gamma_dist_interval"], list):
+        kwargs["gamma_dist_interval"] = tuple(kwargs["gamma_dist_interval"])
+
+    solver = RelayDecoderF64(check_matrix, error_priors, **kwargs)
+    return RelayBPDecoder(vertex_num, num_hyperedges, solver)
+```
+
+This is just hypergraph-to-`csr_matrix` translation plus a constructor call.
+Two things worth pointing out:
+
+- **`config` is forwarded verbatim** to `RelayDecoderF64`. Unknown keys raise
+  `TypeError` straight from the underlying constructor — there is no silent
+  whitelist that would drop typos.
+- The single `gamma_dist_interval` list→tuple coercion exists only because JSON
+  has no tuple type; without it, every user supplying that key from `--py-config`
+  would hit a type error they couldn't fix from the CLI.
+
+That's the whole wrapper. The same shape applies to any decoder: implement
+`decode`/`reset` on a class, and have `new` build it from the hypergraph.
+
+> An analogous wrapper for Google's Tesseract beam-search decoder lives at
+> [deq_runtime/src/decoder/tesseract_decoder.py](../../../deq_runtime/src/decoder/tesseract_decoder.py).
+> It builds a `stim.DetectorErrorModel` instead of a `csr_matrix`, but the
+> protocol is identical.
+
+---
+
+## Running the standard decoder test suite
+
+deq ships a hand-curated suite of 32 decoder unit tests (degenerate
+hypergraphs, single edges, triangles, line chains, etc.) that any black-box
+decoder must pass. Run it against your wrapper with `deq test python-decoder`:
+
+```sh
+deq test python-decoder --file ../../../../deq_runtime/src/decoder/relay_bp_decoder.py
+# ... 32 lines of [PASS]
+# passed: 32/32
+```
+
+Two things to notice:
+
+- This is a thin Python entry point that calls into the installed `deq_runtime`
+  extension module — no Rust toolchain or `cargo` needed at the user's end. If
+  you see `Error: deq_runtime is not installed`, rebuild the bindings with
+  `cd deq_runtime && maturin develop --release --features python_all`.
+- **`--py-config '{...}'`** is optional. It is a JSON object that lands as the
+  `config` argument to your `new`. For example, to pin BP's RNG:
+
+  ```sh
+  deq test python-decoder \
+      --file ../../../../deq_runtime/src/decoder/relay_bp_decoder.py \
+      --py-config '{"seed": 42}'
+  # NOTE: on Windows (cmd/PowerShell), escape inner double quotes,
+  #       e.g. '{\"seed\":42}' instead of '{"seed":42}'
+  ```
+
+If your suite reports `passed: 32/32`, your wrapper satisfies the black-box
+contract; you can move on to driving an actual simulation.
+
+---
+
+## End-to-end: logical error rate on a dynamic circuit
+
+We re-use the [intro chapter's](../README.md) `small_example_evaluation.deq` —
+the only line that changes from the intro is `--decoder` + `--decoder-config`.
+The window coordinator, JIT controller, and JIT static simulator are all
+untouched: the same dynamic-logical-circuit machinery now drives an arbitrary
+Python decoder.
+
+```sh
+# Same transpile step as in the intro
+deq transpile small_example_evaluation.deq --out small_example.deq.jit --program Simulation
+
+# Same server invocation as the intro, but with --decoder black-box-python
+deq server \
+    --decoder black-box-python \
+    --decoder-config '{
+        "file": "../../../../deq_runtime/src/decoder/relay_bp_decoder.py"
+    }' \
+    --coordinator window \
+    --coordinator-config '{"buffer_radius":3}' \
+    --controller jit \
+    --controller-config '{"filepath":"small_example.deq.jit"}' \
+    --simulator jit-static \
+    --simulator-config '{
+        "filepath":"small_example.stim",
+        "jit_library_filepath":"small_example.deq.jit",
+        "shots": 2000,
+        "seed": 123
+    }'
+# server running on "http://[::1]:50051" (port=50051)
+# === Simulation Complete ===
+#   Shots: 2000/2000
+#   Logical errors: 28/4000
+#   Error rate: 1.400000e-2 ± 5.15e-3
+#   Decoding time: 0.524s (2.621e-4s per shot)
+#   Last-batch latency: 0.523s (2.613e-4s per shot)
+```
+
+`black-box-python` accepts the following config:
+
+| Field        | Type           | Meaning                                                                                                |
+| ------------ | -------------- | ------------------------------------------------------------------------------------------------------ |
+| `file`       | string         | Absolute or relative path to your `*.py` file. Must expose `new` plus a `decode`/`reset`-shaped class. |
+| `py_config`  | any JSON value | Forwarded to your `new` as the `config` argument. Omit for `{}`.                                       |
+| `parallel`   | int (optional) | Number of decoder worker threads (inherited from the thread-pooling layer).                            |
+
+Pass `py_config` exactly the way you would pass `--py-config` to
+`test python-decoder`, just nested one level inside the decoder config:
+
+```sh
+--decoder-config '{
+    "file": "deq_runtime/src/decoder/relay_bp_decoder.py",
+    "py_config": {"seed": 42, "num_sets": 100}
+}'
+```
+
+Your decoder's Python dependencies (e.g. `numpy`, `scipy`, `relay_bp` in the
+example above) just need to be importable in the same environment that hosts
+`deq` — `deq_runtime` is loaded as a normal extension module into the running
+interpreter, so no additional setup is required.
+
+---
+
+## When to graduate to Rust
+
+The Python bridge is great for prototyping and for decoders that only exist as
+Python packages. Each `decode()` call still crosses the GIL and pays a small
+serialization cost — deq mitigates this by parallelizing across decoder
+instances via the thread-pooling layer (`parallel` field above), but for
+production latency you'll eventually want to expose your decoder through the
+same `BlackBoxDecoder` Rust trait the built-in `relay-bp` and `tesseract`
+decoders use. By that point you already have a known-good reference
+implementation in Python and a 32-case test suite to validate the Rust port
+against — so the Rust port becomes a refactoring exercise, not a research one.

--- a/deq/pyproject.toml
+++ b/deq/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "deq"
 dynamic = []
-version = "0.3.1"
+version = "0.3.2"
 description = "deq: quantum error correction decoding system."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
This pull request enables automated testing of Python decoders against a standard suite from the Rust runtime. It also improves Python decoder integration by replacing the `pythonize` crate with a custom JSON-to-Python conversion, and adds two example Python decoder wrappers for the `relay-bp` and `tesseract-decoder` libraries. Additionally, there are updates to dependency management and module loading for better isolation and compatibility.
