### PR TITLE
Fix BitwiseForSlice::is_unit for multi-block slices

### DIFF
--- a/binar/src/bit/bitwise_for_slice.rs
+++ b/binar/src/bit/bitwise_for_slice.rs
@@ -36,8 +36,7 @@ where
     }
     #[inline]
     fn is_unit(&self, index: usize) -> bool {
-        let (block_index, bit_index) = block_and_bit_index::<BitBlock>(index);
-        self.borrow()[block_index].is_unit(bit_index)
+        self.weight() == 1 && self.index(index)
     }
     #[inline]
     fn max_support(&self) -> Option<usize> {

--- a/binar/tests/bitmatrix_test.rs
+++ b/binar/tests/bitmatrix_test.rs
@@ -4,7 +4,7 @@ use binar::matrix::{
     kernel_basis_matrix, row_stacked,
 };
 use binar::vec::AlignedBitVec;
-use binar::{Bitwise, BitwiseMut, BitwisePairMut};
+use binar::{BitBlock, BitLength, Bitwise, BitwiseMut, BitwisePairMut};
 use proptest::prelude::*;
 use rand::{RngExt, SeedableRng};
 use sorted_iter::SortedIterator;
@@ -305,14 +305,17 @@ prop_compose! {
 
 #[test]
 fn matrix_row_is_unit_rejects_extra_bits_in_other_blocks() {
-    let mut matrix = AlignedBitMatrix::zeros(1, 128);
-    matrix.set((0, 0), true);
-    matrix.set((0, 100), true);
+    let first_bit_index = 0;
+    let second_block_bit_index = BitBlock::BLOCK_BIT_LEN;
+    let width = second_block_bit_index + 1;
+    let mut matrix = AlignedBitMatrix::zeros(1, width);
+    matrix.set((0, first_bit_index), true);
+    matrix.set((0, second_block_bit_index), true);
 
     let row = matrix.row(0);
     assert_eq!(row.weight(), 2);
-    assert!(!row.is_unit(0));
-    assert!(!row.is_unit(100));
+    assert!(!row.is_unit(first_bit_index));
+    assert!(!row.is_unit(second_block_bit_index));
 }
 
 #[test]

--- a/binar/tests/bitmatrix_test.rs
+++ b/binar/tests/bitmatrix_test.rs
@@ -304,6 +304,18 @@ prop_compose! {
 // }
 
 #[test]
+fn matrix_row_is_unit_rejects_extra_bits_in_other_blocks() {
+    let mut matrix = AlignedBitMatrix::zeros(1, 128);
+    matrix.set((0, 0), true);
+    matrix.set((0, 100), true);
+
+    let row = matrix.row(0);
+    assert_eq!(row.weight(), 2);
+    assert!(!row.is_unit(0));
+    assert!(!row.is_unit(100));
+}
+
+#[test]
 fn test_echelon_form() {
     for _ in 0..100 {
         check_echelon_form_on_random_matrix(100, 100);

--- a/binar/tests/bitvec_test.rs
+++ b/binar/tests/bitvec_test.rs
@@ -1,5 +1,5 @@
 use binar::vec::AlignedBitVec;
-use binar::{BitLength, BitVec, Bitwise, BitwiseMut, BitwisePair, BitwisePairMut};
+use binar::{BitBlock, BitLength, BitVec, Bitwise, BitwiseMut, BitwisePair, BitwisePairMut};
 use proptest::prelude::*;
 
 proptest! {
@@ -89,24 +89,30 @@ proptest! {
 
 #[test]
 fn bitvec_is_unit_rejects_extra_bits_in_other_blocks() {
-    let mut bitvec = BitVec::zeros(128);
-    bitvec.assign_index(0, true);
-    bitvec.assign_index(100, true);
+    let first_bit_index = 0;
+    let second_block_bit_index = BitBlock::BLOCK_BIT_LEN;
+    let width = second_block_bit_index + 1;
+    let mut bitvec = BitVec::zeros(width);
+    bitvec.assign_index(first_bit_index, true);
+    bitvec.assign_index(second_block_bit_index, true);
 
     assert_eq!(bitvec.weight(), 2);
-    assert!(!bitvec.is_unit(0));
-    assert!(!bitvec.is_unit(100));
+    assert!(!bitvec.is_unit(first_bit_index));
+    assert!(!bitvec.is_unit(second_block_bit_index));
 }
 
 #[test]
 fn aligned_bitvec_is_unit_rejects_extra_bits_in_other_blocks() {
-    let mut bitvec = AlignedBitVec::zeros(128);
-    bitvec.assign_index(0, true);
-    bitvec.assign_index(100, true);
+    let first_bit_index = 0;
+    let second_block_bit_index = BitBlock::BLOCK_BIT_LEN;
+    let width = second_block_bit_index + 1;
+    let mut bitvec = AlignedBitVec::zeros(width);
+    bitvec.assign_index(first_bit_index, true);
+    bitvec.assign_index(second_block_bit_index, true);
 
     assert_eq!(bitvec.weight(), 2);
-    assert!(!bitvec.is_unit(0));
-    assert!(!bitvec.is_unit(100));
+    assert!(!bitvec.is_unit(first_bit_index));
+    assert!(!bitvec.is_unit(second_block_bit_index));
 }
 
 fn arbitrary_bitvec(max_length: usize) -> impl Strategy<Value = AlignedBitVec> {

--- a/binar/tests/bitvec_test.rs
+++ b/binar/tests/bitvec_test.rs
@@ -1,5 +1,5 @@
 use binar::vec::AlignedBitVec;
-use binar::{BitLength, Bitwise, BitwiseMut, BitwisePair, BitwisePairMut};
+use binar::{BitLength, BitVec, Bitwise, BitwiseMut, BitwisePair, BitwisePairMut};
 use proptest::prelude::*;
 
 proptest! {
@@ -85,6 +85,28 @@ proptest! {
         assert_eq!(left.dot(&right), expected);
     }
 
+}
+
+#[test]
+fn bitvec_is_unit_rejects_extra_bits_in_other_blocks() {
+    let mut bitvec = BitVec::zeros(128);
+    bitvec.assign_index(0, true);
+    bitvec.assign_index(100, true);
+
+    assert_eq!(bitvec.weight(), 2);
+    assert!(!bitvec.is_unit(0));
+    assert!(!bitvec.is_unit(100));
+}
+
+#[test]
+fn aligned_bitvec_is_unit_rejects_extra_bits_in_other_blocks() {
+    let mut bitvec = AlignedBitVec::zeros(128);
+    bitvec.assign_index(0, true);
+    bitvec.assign_index(100, true);
+
+    assert_eq!(bitvec.weight(), 2);
+    assert!(!bitvec.is_unit(0));
+    assert!(!bitvec.is_unit(100));
 }
 
 fn arbitrary_bitvec(max_length: usize) -> impl Strategy<Value = AlignedBitVec> {


### PR DESCRIPTION
Fixes #53 

## Summary

Follows the fixes set out in #53 exactly. Fixes `BitwiseForSlice::is_unit` so that it checks the full slice, not only the single block containing the queried index. Previously, multi-block slices could incorrectly report `is_unit(index) == true` when the queried block contained a unit bit but another block also had a bit set.
## Changes
- Updated `BitwiseForSlice::is_unit` to use the global semantics: `self.weight() == 1 && self.index(index)`
- Added the suggested regression tests for:
  - `BitVec`
  - `AlignedBitVec`
  - `BitMatrix` row views

## Validation
- `cargo test -p binar --test bitvec_test is_unit --quiet`
- `cargo test -p binar --test bitmatrix_test matrix_row_is_unit_rejects_extra_bits_in_other_blocks --quiet`
- `cargo test -p binar --lib --tests --all-features --quiet`
- `cargo clippy -p binar --all-targets --all-features -- -D clippy::pedantic`
- `cargo test -p binar --all-targets --all-features` 
 
