### PR TITLE
pauliverse/paulimer: expose FramePropagator to Python, add reset_qubit, fix swapped Clifford gates

### DIFF
--- a/paulimer/bindings/python/paulimer.pyi
+++ b/paulimer/bindings/python/paulimer.pyi
@@ -19,6 +19,7 @@ __all__ = [
     "CliffordUnitary",
     "DensePauli",
     "FaultySimulation",
+    "FramePropagator",
     "OutcomeCompleteSimulation",
     "OutcomeCondition",
     "OutcomeFreeSimulation",
@@ -1648,6 +1649,101 @@ class FaultySimulation:
         Returns:
             BitMatrix with shape (shots, outcome_count) containing measurement outcomes.
             The result is row-major.  Each shot corresponds to a row.
+        """
+        ...
+
+    def __repr__(self) -> str: ...
+
+@final
+class FramePropagator:
+    """Heisenberg-picture batched Pauli error frame propagator.
+
+    Tracks Pauli errors injected at arbitrary points in a circuit across many
+    shots in parallel. Internally maintains ``(qubit_count x shot_count)`` X
+    and Z bit matrices and an ``(outcome_count x shot_count)`` matrix of
+    outcome deltas (per-shot XOR against the noiseless trajectory).
+
+    Workflow:
+        1. Construct with the qubit, outcome and shot capacities of your
+           circuit.
+        2. Walk the circuit: at the desired locations call
+           :meth:`inject_pauli` to inject a fault for one shot.
+        3. Apply gates via the simulation-style methods and record
+           measurements via :meth:`measure`.
+        4. Read :attr:`outcome_deltas` to get the per-shot outcome flips
+           relative to the noiseless trajectory.
+
+    Pauli gates are no-ops in frame propagation (they commute through Pauli
+    errors up to a phase). The ``parity`` argument of
+    :meth:`apply_conditional_pauli` is accepted for API compatibility but
+    ignored: only the *delta* of the condition matters when propagating
+    error frames.
+    """
+
+    def __new__(cls, qubit_count: int, outcome_count: int, shot_count: int) -> "FramePropagator":
+        """Create a new propagator.
+
+        Args:
+            qubit_count: Number of qubits to track.
+            outcome_count: Number of measurement outcomes the circuit will produce.
+            shot_count: Number of independent shots to run in parallel.
+        """
+        ...
+
+    @property
+    def qubit_count(self) -> int: ...
+    @property
+    def outcome_count(self) -> int: ...
+    @property
+    def shot_count(self) -> int: ...
+
+    def apply_unitary(self, opcode: UnitaryOpcode, qubits: Sequence[int]) -> None: ...
+    def apply_clifford(
+        self, clifford: CliffordUnitary, qubits: Sequence[int] | None = None
+    ) -> None: ...
+    def apply_pauli(
+        self, pauli: SparsePauli, controlled_by: SparsePauli | None = None
+    ) -> None: ...
+    def apply_pauli_exp(self, pauli: SparsePauli) -> None: ...
+    def apply_permutation(
+        self, permutation: Sequence[int], qubits: Sequence[int] | None = None
+    ) -> None: ...
+    def apply_conditional_pauli(
+        self, pauli: SparsePauli, outcomes: Sequence[int], parity: bool = True
+    ) -> None: ...
+    def measure(self, observable: SparsePauli, hint: SparsePauli | None = None) -> int: ...
+    def allocate_random_bit(self) -> int: ...
+
+    def inject_pauli(self, shot: int, pauli: SparsePauli) -> None:
+        """Inject a Pauli error into the frame for a specific shot.
+
+        Args:
+            shot: Index of the shot, ``0 <= shot < shot_count``.
+            pauli: Sparse Pauli error to XOR into the frame.
+
+        Raises:
+            IndexError: if ``shot`` is out of range, or ``pauli`` acts on a
+                qubit beyond ``qubit_count``.
+        """
+        ...
+
+    def reset_qubit(self, qubit: int) -> None:
+        """Reset a qubit, clearing its accumulated error frame across all shots.
+
+        Args:
+            qubit: Index of the qubit, ``0 <= qubit < qubit_count``.
+
+        Raises:
+            IndexError: if ``qubit`` is out of range.
+        """
+        ...
+
+    @property
+    def outcome_deltas(self) -> BitMatrix:
+        """Outcome delta matrix of shape ``(outcome_count, shot_count)``.
+
+        Bit ``(o, s)`` is true iff outcome ``o`` in shot ``s`` differs from
+        the noiseless trajectory.
         """
         ...
 

--- a/paulimer/bindings/python/src/lib.rs
+++ b/paulimer/bindings/python/src/lib.rs
@@ -5,6 +5,7 @@ mod format_spec;
 mod py_clifford;
 mod py_dense_pauli;
 mod py_faulty_simulation;
+mod py_frame_propagator;
 mod py_noise;
 mod py_pauli_group;
 mod py_sparse_pauli;
@@ -17,6 +18,7 @@ pub use py_clifford::{
 };
 pub use py_dense_pauli::PyDensePauli;
 pub use py_faulty_simulation::PyFaultySimulation;
+pub use py_frame_propagator::PyFramePropagator;
 pub use py_noise::{PyFault, PyOutcomeCondition, PyPauliDistribution};
 pub use py_pauli_group::{py_centralizer_of, py_symplectic_form_of, PyPauliGroup};
 pub use py_sparse_pauli::PySparsePauli;
@@ -36,6 +38,7 @@ pub fn paulimer(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyOutcomeSpecificSimulation>()?;
     m.add_class::<PyOutcomeFreeSimulation>()?;
     m.add_class::<PyFaultySimulation>()?;
+    m.add_class::<PyFramePropagator>()?;
     m.add_class::<PyFault>()?;
     m.add_class::<PyPauliDistribution>()?;
     m.add_class::<PyOutcomeCondition>()?;

--- a/paulimer/bindings/python/src/py_frame_propagator.rs
+++ b/paulimer/bindings/python/src/py_frame_propagator.rs
@@ -130,6 +130,11 @@ impl PyFramePropagator {
     /// Raises:
     ///     IndexError: if `shot` is out of range, or `pauli` acts on a qubit
     ///         beyond `qubit_count`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a Python `IndexError` if `shot >= shot_count` or `pauli` acts on
+    /// a qubit index `>= qubit_count`.
     pub fn inject_pauli(&mut self, shot: usize, pauli: &PySparsePauli) -> PyResult<()> {
         let shot_count = self.inner.shot_count();
         if shot >= shot_count {
@@ -153,6 +158,10 @@ impl PyFramePropagator {
     ///
     /// Raises:
     ///     IndexError: if `qubit` is out of range.
+    ///
+    /// # Errors
+    ///
+    /// Returns a Python `IndexError` if `qubit >= qubit_count`.
     pub fn reset_qubit(&mut self, qubit: usize) -> PyResult<()> {
         let qubit_count = Simulation::qubit_count(&self.inner);
         if qubit >= qubit_count {

--- a/paulimer/bindings/python/src/py_frame_propagator.rs
+++ b/paulimer/bindings/python/src/py_frame_propagator.rs
@@ -1,0 +1,184 @@
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::doc_markdown)]
+#![allow(clippy::needless_pass_by_value)]
+
+use crate::{PyCliffordUnitary, PySparsePauli, PyUnitaryOp};
+use binar::BitMatrix;
+use paulimer::clifford::Clifford;
+use paulimer::pauli::Pauli;
+use pauliverse::{FramePropagator, Simulation};
+use pyo3::exceptions::PyIndexError;
+use pyo3::prelude::*;
+
+/// Heisenberg-picture batched Pauli error frame propagator.
+///
+/// Tracks Pauli errors injected at arbitrary points in a circuit across many
+/// shots in parallel using `(qubit_count × shot_count)` X/Z bit matrices and
+/// an `(outcome_count × shot_count)` matrix of outcome deltas (per-shot XOR
+/// against the noiseless trajectory).
+///
+/// Typical workflow:
+///
+/// 1. Construct with the qubit/outcome/shot capacities of your circuit.
+/// 2. Walk the circuit; at the desired locations call `inject_pauli` to inject
+///    the fault for one shot.
+/// 3. Apply gates via `apply_unitary` / `apply_clifford` / etc. and record
+///    measurements via `measure`.
+/// 4. Read `outcome_deltas` to get the per-shot outcome flips relative to the
+///    noiseless trajectory.
+///
+/// Pauli gates are no-ops in frame propagation (they commute through Pauli
+/// errors up to a phase). The `parity` argument of `apply_conditional_pauli`
+/// is accepted for API compatibility but ignored: only the delta of the
+/// condition matters when propagating error frames.
+#[pyclass(name = "FramePropagator", unsendable)]
+pub struct PyFramePropagator {
+    inner: FramePropagator,
+}
+
+#[pymethods]
+impl PyFramePropagator {
+    /// Create a new propagator.
+    ///
+    /// Args:
+    ///     qubit_count: Number of qubits to track.
+    ///     outcome_count: Number of measurement outcomes the circuit will produce.
+    ///     shot_count: Number of independent shots to run in parallel.
+    #[new]
+    #[pyo3(signature = (qubit_count, outcome_count, shot_count))]
+    pub fn new(qubit_count: usize, outcome_count: usize, shot_count: usize) -> Self {
+        PyFramePropagator {
+            inner: FramePropagator::new(qubit_count, outcome_count, shot_count),
+        }
+    }
+
+    #[getter]
+    pub fn qubit_count(&self) -> usize {
+        Simulation::qubit_count(&self.inner)
+    }
+
+    #[getter]
+    pub fn outcome_count(&self) -> usize {
+        Simulation::outcome_count(&self.inner)
+    }
+
+    #[getter]
+    pub fn shot_count(&self) -> usize {
+        self.inner.shot_count()
+    }
+
+    /// Apply a unitary gate.
+    pub fn apply_unitary(&mut self, opcode: &PyUnitaryOp, qubits: Vec<usize>) {
+        self.inner.unitary_op(opcode.clone().into(), &qubits);
+    }
+
+    /// Apply a Clifford unitary.
+    #[pyo3(signature = (clifford, qubits=None))]
+    pub fn apply_clifford(&mut self, clifford: &PyCliffordUnitary, qubits: Option<Vec<usize>>) {
+        let qubits = qubits.unwrap_or_else(|| (0..clifford.inner.num_qubits()).collect());
+        self.inner.clifford(&clifford.inner, &qubits);
+    }
+
+    /// Apply a Pauli gate (no-op for frame propagation).
+    #[pyo3(signature = (pauli, controlled_by=None))]
+    pub fn apply_pauli(&mut self, pauli: &PySparsePauli, controlled_by: Option<&PySparsePauli>) {
+        if let Some(control) = controlled_by {
+            self.inner.controlled_pauli(&control.inner, &pauli.inner);
+        } else {
+            self.inner.pauli(&pauli.inner);
+        }
+    }
+
+    /// Apply a Pauli exponential (e^{-iπ/4 P}).
+    pub fn apply_pauli_exp(&mut self, pauli: &PySparsePauli) {
+        self.inner.pauli_exp(&pauli.inner);
+    }
+
+    /// Apply a permutation.
+    #[pyo3(signature = (permutation, qubits=None))]
+    pub fn apply_permutation(&mut self, permutation: Vec<usize>, qubits: Option<Vec<usize>>) {
+        let qubits = qubits.unwrap_or_else(|| (0..permutation.len()).collect());
+        self.inner.permute(&permutation, &qubits);
+    }
+
+    /// Apply a conditional Pauli based on previous outcome ids.
+    ///
+    /// `parity` is accepted for API compatibility but ignored: in frame
+    /// propagation, only the delta of the condition matters.
+    #[pyo3(signature = (pauli, outcomes, parity=true))]
+    pub fn apply_conditional_pauli(&mut self, pauli: &PySparsePauli, outcomes: Vec<usize>, parity: bool) {
+        self.inner.conditional_pauli(&pauli.inner, &outcomes, parity);
+    }
+
+    /// Record a measurement of `observable` and return the assigned outcome id.
+    ///
+    /// `hint` is accepted for API compatibility with other simulation backends
+    /// and ignored.
+    #[pyo3(signature = (observable, hint=None))]
+    pub fn measure(&mut self, observable: &PySparsePauli, hint: Option<&PySparsePauli>) -> usize {
+        let _ = hint;
+        Simulation::measure(&mut self.inner, &observable.inner)
+    }
+
+    /// Allocate a random measurement outcome (no anti-commutation update).
+    pub fn allocate_random_bit(&mut self) -> usize {
+        Simulation::allocate_random_bit(&mut self.inner)
+    }
+
+    /// Inject a Pauli error into a specific shot at the current circuit position.
+    ///
+    /// Raises:
+    ///     IndexError: if `shot` is out of range, or `pauli` acts on a qubit
+    ///         beyond `qubit_count`.
+    pub fn inject_pauli(&mut self, shot: usize, pauli: &PySparsePauli) -> PyResult<()> {
+        let shot_count = self.inner.shot_count();
+        if shot >= shot_count {
+            return Err(PyIndexError::new_err(format!(
+                "shot {shot} out of range (shot_count = {shot_count})"
+            )));
+        }
+        let qubit_count = Simulation::qubit_count(&self.inner);
+        if let Some(max_qubit) = pauli.inner.max_support() {
+            if max_qubit >= qubit_count {
+                return Err(PyIndexError::new_err(format!(
+                    "pauli acts on qubit {max_qubit} out of range (qubit_count = {qubit_count})"
+                )));
+            }
+        }
+        self.inner.inject_pauli(shot, &pauli.inner);
+        Ok(())
+    }
+
+    /// Reset a qubit, clearing its accumulated error frame across all shots.
+    ///
+    /// Raises:
+    ///     IndexError: if `qubit` is out of range.
+    pub fn reset_qubit(&mut self, qubit: usize) -> PyResult<()> {
+        let qubit_count = Simulation::qubit_count(&self.inner);
+        if qubit >= qubit_count {
+            return Err(PyIndexError::new_err(format!(
+                "qubit {qubit} out of range (qubit_count = {qubit_count})"
+            )));
+        }
+        self.inner.reset_qubit(qubit);
+        Ok(())
+    }
+
+    /// Outcome delta matrix: `(outcome_count × shot_count)` row-major bits.
+    ///
+    /// Bit `(o, s)` is true iff outcome `o` in shot `s` differs from the
+    /// noiseless trajectory.
+    #[getter]
+    pub fn outcome_deltas(&self) -> BitMatrix {
+        self.inner.outcome_deltas().clone().into()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "FramePropagator(qubit_count={}, outcome_count={}, shot_count={})",
+            Simulation::qubit_count(&self.inner),
+            Simulation::outcome_count(&self.inner),
+            self.inner.shot_count(),
+        )
+    }
+}

--- a/paulimer/bindings/python/tests/test_frame_propagator.py
+++ b/paulimer/bindings/python/tests/test_frame_propagator.py
@@ -1,0 +1,85 @@
+"""Tests for the FramePropagator Python binding.
+
+Covers construction/getters, per-shot injection, reset_qubit semantics,
+measure-and-reset ordering, out-of-range error handling, and a regression
+guard that the S gate propagates errors correctly through the binding.
+"""
+
+import pytest
+from binar import BitMatrix
+from paulimer import FramePropagator, SparsePauli, UnitaryOpcode
+
+
+class TestBasics:
+    def test_getters(self):
+        fp = FramePropagator(3, 5, 7)
+        assert fp.qubit_count == 3
+        # outcome_count grows as measurements are recorded; starts at 0.
+        assert fp.outcome_count == 0
+        assert fp.shot_count == 7
+
+    def test_outcome_deltas_is_bitmatrix(self):
+        fp = FramePropagator(1, 1, 1)
+        fp.measure(SparsePauli("Z"))
+        assert isinstance(fp.outcome_deltas, BitMatrix)
+
+
+class TestInjectionAndMeasurement:
+    def test_per_shot_injection_is_independent(self):
+        # Shot 0: X on control spreads through CNOT to flip both Z measurements.
+        # Shot 1: Z on target commutes with both Z measurements -> no flips.
+        fp = FramePropagator(2, 2, 2)
+        fp.inject_pauli(0, SparsePauli("XI"))
+        fp.inject_pauli(1, SparsePauli("IZ"))
+        fp.apply_unitary(UnitaryOpcode.ControlledX, [0, 1])
+        fp.measure(SparsePauli("ZI"))
+        fp.measure(SparsePauli("IZ"))
+        d = fp.outcome_deltas
+        assert d[0, 0] and d[1, 0]
+        assert not d[0, 1] and not d[1, 1]
+
+    def test_s_gate_maps_x_error_to_y(self):
+        # Regression for the apply_s/apply_sqrt_x swap: S(X) = Y, so a Z
+        # measurement (anticommuting with the X part of Y) must flip.
+        fp = FramePropagator(1, 1, 1)
+        fp.inject_pauli(0, SparsePauli("X"))
+        fp.apply_unitary(UnitaryOpcode.SqrtZ, [0])
+        fp.measure(SparsePauli("Z"))
+        assert fp.outcome_deltas[0, 0]
+
+
+class TestReset:
+    def test_reset_clears_frame(self):
+        fp = FramePropagator(1, 1, 1)
+        fp.inject_pauli(0, SparsePauli("Z"))
+        fp.reset_qubit(0)
+        fp.apply_unitary(UnitaryOpcode.Hadamard, [0])
+        fp.measure(SparsePauli("Z"))
+        assert not fp.outcome_deltas[0, 0]
+
+    def test_measure_then_reset_records_delta_before_clearing(self):
+        fp = FramePropagator(1, 2, 1)
+        fp.inject_pauli(0, SparsePauli("X"))
+        fp.measure(SparsePauli("Z"))  # pre-reset: X flips Z
+        fp.reset_qubit(0)
+        fp.apply_unitary(UnitaryOpcode.Hadamard, [0])
+        fp.measure(SparsePauli("Z"))  # post-reset: clean
+        d = fp.outcome_deltas
+        assert d[0, 0] and not d[1, 0]
+
+
+class TestBounds:
+    def test_reset_qubit_out_of_range(self):
+        fp = FramePropagator(2, 1, 2)
+        with pytest.raises(IndexError):
+            fp.reset_qubit(2)
+
+    def test_inject_shot_out_of_range(self):
+        fp = FramePropagator(2, 1, 2)
+        with pytest.raises(IndexError):
+            fp.inject_pauli(2, SparsePauli("XI"))
+
+    def test_inject_qubit_out_of_range(self):
+        fp = FramePropagator(2, 1, 2)
+        with pytest.raises(IndexError):
+            fp.inject_pauli(0, SparsePauli("IIX"))  # X on qubit 2

--- a/pauliverse/src/frame_propagator.rs
+++ b/pauliverse/src/frame_propagator.rs
@@ -527,15 +527,14 @@ impl FramePropagator {
     ///
     /// # Panics
     ///
-    /// In debug builds, panics if `shot >= self.shot_count` or a qubit in
-    /// `pauli.support()` is out of range. In release builds these bounds are
-    /// unchecked, so the caller must ensure `shot` and every support qubit are
-    /// in range; passing an out-of-range index is undefined behavior.
+    /// Panics if `shot >= self.shot_count` or a qubit in `pauli.support()` is
+    /// out of range. These bounds are always checked, making this the safe
+    /// public entry point over the unchecked [`Self::apply_pauli_to_shot`].
     pub fn inject_pauli(&mut self, shot: usize, pauli: &SparsePauli) {
         let qubit_count = self.qubit_count();
-        debug_assert!(shot < self.shot_count, "shot out of range");
+        assert!(shot < self.shot_count, "shot out of range");
         for qubit in pauli.support() {
-            debug_assert!(qubit < qubit_count, "fault qubit {qubit} out of range 0..{qubit_count}");
+            assert!(qubit < qubit_count, "fault qubit {qubit} out of range 0..{qubit_count}");
         }
         self.apply_pauli_to_shot(shot, pauli);
     }

--- a/pauliverse/src/frame_propagator.rs
+++ b/pauliverse/src/frame_propagator.rs
@@ -67,6 +67,19 @@ impl FramePropagator {
         self.outcome_deltas
     }
 
+    /// Borrow the current outcome deltas matrix without consuming the propagator.
+    ///
+    /// Layout: `(n_outcomes × n_shots)` - each row is the error delta for one outcome.
+    pub fn outcome_deltas(&self) -> &AlignedBitMatrix {
+        &self.outcome_deltas
+    }
+
+    /// Number of shots tracked in parallel.
+    #[must_use]
+    pub fn shot_count(&self) -> usize {
+        self.shot_count
+    }
+
     /// Number of qubits tracked in the error frame.
     fn qubit_count(&self) -> usize {
         self.x_frames.shape().0
@@ -322,7 +335,9 @@ impl FramePropagator {
     ///
     /// Computes the anti-commutation of the current frame with the observable
     /// and XORs the result into the outcome delta for this measurement.
-    pub fn measure<P: Pauli>(&mut self, observable: &P)
+    ///
+    /// Returns the newly assigned outcome id.
+    pub fn measure<P: Pauli>(&mut self, observable: &P) -> OutcomeId
     where
         P::Bits: Bitwise,
     {
@@ -331,6 +346,7 @@ impl FramePropagator {
 
         let anticommutes = self.anticommutation_mask(observable);
         self.outcome_deltas.row_mut(outcome_id).bitxor_assign(&anticommutes);
+        outcome_id
     }
 
     /// Apply a conditional Pauli gate based on outcome parity.
@@ -364,9 +380,11 @@ impl FramePropagator {
 
     /// Advance the outcome counter without computing anti-commutation.
     ///
-    /// Used for `AllocateRandomBit` instructions.
-    pub fn skip_outcome(&mut self) {
+    /// Used for `AllocateRandomBit` instructions. Returns the assigned outcome id.
+    pub fn skip_outcome(&mut self) -> OutcomeId {
+        let outcome_id = self.next_outcome_id;
         self.next_outcome_id += 1;
+        outcome_id
     }
 
     // ========== Noise Injection ==========
@@ -584,6 +602,150 @@ impl FramePropagator {
             Instruction::Noise { fault } => {
                 self.inject_noise(fault, base_seed, noiseless_outcomes, rng);
             }
+        }
+    }
+}
+
+impl Default for FramePropagator {
+    fn default() -> Self {
+        Self::new(0, 0, 1)
+    }
+}
+
+impl crate::Simulation for FramePropagator {
+    fn allocate_random_bit(&mut self) -> OutcomeId {
+        self.ensure_outcome_capacity();
+        self.skip_outcome()
+    }
+
+    fn clifford(&mut self, clifford: &CliffordUnitary, support: &[QubitId]) {
+        self.ensure_qubit_capacity_for(support);
+        self.apply_clifford(clifford, support);
+    }
+
+    fn conditional_pauli(&mut self, observable: &SparsePauli, outcomes: &[OutcomeId], _parity: bool) {
+        self.ensure_qubit_capacity_for_pauli(observable);
+        self.apply_conditional_pauli(observable, outcomes);
+    }
+
+    fn controlled_pauli(&mut self, observable1: &SparsePauli, observable2: &SparsePauli) {
+        self.ensure_qubit_capacity_for_pauli(observable1);
+        self.ensure_qubit_capacity_for_pauli(observable2);
+        self.apply_controlled_pauli(observable1, observable2);
+    }
+
+    fn pauli(&mut self, _observable: &SparsePauli) {
+        // Pauli gates commute with all Pauli frames (mod phase): no-op.
+    }
+
+    fn pauli_exp(&mut self, sparse_pauli: &SparsePauli) {
+        self.ensure_qubit_capacity_for_pauli(sparse_pauli);
+        self.apply_pauli_exp(sparse_pauli);
+    }
+
+    fn permute(&mut self, permutation: &[usize], support: &[QubitId]) {
+        self.ensure_qubit_capacity_for(support);
+        self.apply_permutation(permutation, support);
+    }
+
+    fn unitary_op(&mut self, operation: UnitaryOp, support: &[QubitId]) {
+        self.ensure_qubit_capacity_for(support);
+        self.apply_unitary_op(operation, support);
+    }
+
+    fn measure(&mut self, observable: &SparsePauli) -> OutcomeId {
+        self.ensure_qubit_capacity_for_pauli(observable);
+        self.ensure_outcome_capacity();
+        FramePropagator::measure(self, observable)
+    }
+
+    fn measure_with_hint(&mut self, observable: &SparsePauli, _hint: &SparsePauli) -> OutcomeId {
+        crate::Simulation::measure(self, observable)
+    }
+
+    // FramePropagator tracks Pauli error frames (deltas from a reference
+    // trajectory), not the stabilizer group of a state, so it cannot answer
+    // stabilizer queries. Mirror `CircuitBuilder`'s builder-style stubs; these
+    // are never exercised on the frame-propagation path (driven via `execute`
+    // and the Python binding's gate/measure methods).
+    fn is_stabilizer(&self, _observable: &SparsePauli) -> bool {
+        true
+    }
+
+    fn is_stabilizer_up_to_sign(&self, _observable: &SparsePauli) -> bool {
+        true
+    }
+
+    fn is_stabilizer_with_conditional_sign(&self, _observable: &SparsePauli, _outcomes: &[OutcomeId]) -> bool {
+        true
+    }
+
+    fn qubit_count(&self) -> usize {
+        self.x_frames.row_count()
+    }
+
+    fn outcome_count(&self) -> usize {
+        self.next_outcome_id
+    }
+
+    fn with_capacity(qubit_count: usize, outcome_count: usize, _random_outcome_count: usize) -> Self {
+        Self::new(qubit_count, outcome_count, 1)
+    }
+
+    fn qubit_capacity(&self) -> usize {
+        self.x_frames.row_count()
+    }
+
+    fn reserve_qubits(&mut self, new_qubit_capacity: usize) {
+        if new_qubit_capacity > self.qubit_capacity() {
+            self.x_frames.resize(new_qubit_capacity, self.shot_count);
+            self.z_frames.resize(new_qubit_capacity, self.shot_count);
+        }
+    }
+
+    fn outcome_capacity(&self) -> usize {
+        self.outcome_deltas.row_count()
+    }
+
+    fn random_outcome_capacity(&self) -> usize {
+        self.outcome_deltas.row_count()
+    }
+
+    fn reserve_outcomes(&mut self, new_outcome_capacity: usize, new_random_outcome_capacity: usize) {
+        let new_capacity = new_outcome_capacity.max(new_random_outcome_capacity);
+        if new_capacity > self.outcome_capacity() {
+            self.outcome_deltas.resize(new_capacity, self.shot_count);
+        }
+    }
+}
+
+impl FramePropagator {
+    fn ensure_qubit_capacity_for(&mut self, support: &[QubitId]) {
+        let max_qubit = support.iter().copied().max().map_or(0, |q| q + 1);
+        if max_qubit > self.x_frames.row_count() {
+            self.x_frames.resize(max_qubit, self.shot_count);
+            self.z_frames.resize(max_qubit, self.shot_count);
+        }
+    }
+
+    fn ensure_qubit_capacity_for_pauli<P: Pauli>(&mut self, pauli: &P)
+    where
+        P::Bits: Bitwise,
+    {
+        let Some(max_index) = pauli.max_support() else { return };
+        let max_qubit = max_index + 1;
+        if max_qubit > self.x_frames.row_count() {
+            self.x_frames.resize(max_qubit, self.shot_count);
+            self.z_frames.resize(max_qubit, self.shot_count);
+        }
+    }
+
+    fn ensure_outcome_capacity(&mut self) {
+        if self.next_outcome_id >= self.outcome_deltas.row_count() {
+            let new_capacity = (self.outcome_deltas.row_count() * 2)
+                .max(self.next_outcome_id + 1)
+                .max(8);
+            self.outcome_deltas.resize(new_capacity, self.shot_count);
         }
     }
 }

--- a/pauliverse/src/frame_propagator.rs
+++ b/pauliverse/src/frame_propagator.rs
@@ -603,6 +603,38 @@ impl FramePropagator {
             }
         }
     }
+
+    // ========== Capacity management (Simulation auto-growth) ==========
+
+    /// Grow the X/Z frame matrices so at least `qubit_count` qubits are tracked.
+    fn grow_qubits(&mut self, qubit_count: usize) {
+        if qubit_count > self.x_frames.row_count() {
+            self.x_frames.resize(qubit_count, self.shot_count);
+            self.z_frames.resize(qubit_count, self.shot_count);
+        }
+    }
+
+    fn ensure_qubit_capacity_for(&mut self, support: &[QubitId]) {
+        let max_qubit = support.iter().copied().max().map_or(0, |q| q + 1);
+        self.grow_qubits(max_qubit);
+    }
+
+    fn ensure_qubit_capacity_for_pauli<P: Pauli>(&mut self, pauli: &P)
+    where
+        P::Bits: Bitwise,
+    {
+        let Some(max_index) = pauli.max_support() else { return };
+        self.grow_qubits(max_index + 1);
+    }
+
+    fn ensure_outcome_capacity(&mut self) {
+        if self.next_outcome_id >= self.outcome_deltas.row_count() {
+            let new_capacity = (self.outcome_deltas.row_count() * 2)
+                .max(self.next_outcome_id + 1)
+                .max(8);
+            self.outcome_deltas.resize(new_capacity, self.shot_count);
+        }
+    }
 }
 
 impl Default for FramePropagator {
@@ -710,38 +742,6 @@ impl crate::Simulation for FramePropagator {
     fn reserve_outcomes(&mut self, new_outcome_capacity: usize, new_random_outcome_capacity: usize) {
         let new_capacity = new_outcome_capacity.max(new_random_outcome_capacity);
         if new_capacity > self.outcome_capacity() {
-            self.outcome_deltas.resize(new_capacity, self.shot_count);
-        }
-    }
-}
-
-impl FramePropagator {
-    /// Grow the X/Z frame matrices so at least `qubit_count` qubits are tracked.
-    fn grow_qubits(&mut self, qubit_count: usize) {
-        if qubit_count > self.x_frames.row_count() {
-            self.x_frames.resize(qubit_count, self.shot_count);
-            self.z_frames.resize(qubit_count, self.shot_count);
-        }
-    }
-
-    fn ensure_qubit_capacity_for(&mut self, support: &[QubitId]) {
-        let max_qubit = support.iter().copied().max().map_or(0, |q| q + 1);
-        self.grow_qubits(max_qubit);
-    }
-
-    fn ensure_qubit_capacity_for_pauli<P: Pauli>(&mut self, pauli: &P)
-    where
-        P::Bits: Bitwise,
-    {
-        let Some(max_index) = pauli.max_support() else { return };
-        self.grow_qubits(max_index + 1);
-    }
-
-    fn ensure_outcome_capacity(&mut self) {
-        if self.next_outcome_id >= self.outcome_deltas.row_count() {
-            let new_capacity = (self.outcome_deltas.row_count() * 2)
-                .max(self.next_outcome_id + 1)
-                .max(8);
             self.outcome_deltas.resize(new_capacity, self.shot_count);
         }
     }

--- a/pauliverse/src/frame_propagator.rs
+++ b/pauliverse/src/frame_propagator.rs
@@ -696,10 +696,7 @@ impl crate::Simulation for FramePropagator {
     }
 
     fn reserve_qubits(&mut self, new_qubit_capacity: usize) {
-        if new_qubit_capacity > self.qubit_capacity() {
-            self.x_frames.resize(new_qubit_capacity, self.shot_count);
-            self.z_frames.resize(new_qubit_capacity, self.shot_count);
-        }
+        self.grow_qubits(new_qubit_capacity);
     }
 
     fn outcome_capacity(&self) -> usize {
@@ -719,12 +716,17 @@ impl crate::Simulation for FramePropagator {
 }
 
 impl FramePropagator {
+    /// Grow the X/Z frame matrices so at least `qubit_count` qubits are tracked.
+    fn grow_qubits(&mut self, qubit_count: usize) {
+        if qubit_count > self.x_frames.row_count() {
+            self.x_frames.resize(qubit_count, self.shot_count);
+            self.z_frames.resize(qubit_count, self.shot_count);
+        }
+    }
+
     fn ensure_qubit_capacity_for(&mut self, support: &[QubitId]) {
         let max_qubit = support.iter().copied().max().map_or(0, |q| q + 1);
-        if max_qubit > self.x_frames.row_count() {
-            self.x_frames.resize(max_qubit, self.shot_count);
-            self.z_frames.resize(max_qubit, self.shot_count);
-        }
+        self.grow_qubits(max_qubit);
     }
 
     fn ensure_qubit_capacity_for_pauli<P: Pauli>(&mut self, pauli: &P)
@@ -732,11 +734,7 @@ impl FramePropagator {
         P::Bits: Bitwise,
     {
         let Some(max_index) = pauli.max_support() else { return };
-        let max_qubit = max_index + 1;
-        if max_qubit > self.x_frames.row_count() {
-            self.x_frames.resize(max_qubit, self.shot_count);
-            self.z_frames.resize(max_qubit, self.shot_count);
-        }
+        self.grow_qubits(max_index + 1);
     }
 
     fn ensure_outcome_capacity(&mut self) {

--- a/pauliverse/src/frame_propagator.rs
+++ b/pauliverse/src/frame_propagator.rs
@@ -131,8 +131,8 @@ impl FramePropagator {
     ///
     /// Note: S† has the same effect on Pauli frames (we track mod phase).
     pub fn apply_s(&mut self, qubit: QubitId) {
-        let z_row = self.z_frames.row(qubit);
-        self.x_frames.row_mut(qubit).bitxor_assign(&z_row);
+        let x_row = self.x_frames.row(qubit);
+        self.z_frames.row_mut(qubit).bitxor_assign(&x_row);
     }
 
     /// Apply CNOT(control, target): X_c → X_c X_t, Z_t → Z_c Z_t
@@ -165,9 +165,12 @@ impl FramePropagator {
     /// Apply √X on qubit q: Z → -Y = ZX, X → X
     ///
     /// Note: √X† has the same effect on Pauli frames (we track mod phase).
+    /// Apply √X on qubit q: Z → Y = iXZ, so Z → XZ (mod phase), X → X
+    ///
+    /// Note: √X† has the same effect on Pauli frames (we track mod phase).
     pub fn apply_sqrt_x(&mut self, qubit: QubitId) {
-        let x_row = self.x_frames.row(qubit);
-        self.z_frames.row_mut(qubit).bitxor_assign(&x_row);
+        let z_row = self.z_frames.row(qubit);
+        self.x_frames.row_mut(qubit).bitxor_assign(&z_row);
     }
 
     /// Apply a `UnitaryOp` to the frames.
@@ -597,6 +600,104 @@ mod tests {
     use rand::rngs::SmallRng;
     use smallvec::smallvec;
     use std::str::FromStr;
+
+    /// Apply a single-qubit gate to each basis Pauli (X, Z, Y) and return the
+    /// resulting `(x, z)` frame bits, so gate conjugation can be checked
+    /// against the Heisenberg table.
+    fn single_qubit_frame_map(gate: impl Fn(&mut FramePropagator, QubitId)) -> [(bool, bool); 3] {
+        // Inputs: X = (1, 0), Z = (0, 1), Y = (1, 1).
+        let inputs = [(true, false), (false, true), (true, true)];
+        let mut out = [(false, false); 3];
+        for (i, &(x, z)) in inputs.iter().enumerate() {
+            let mut fp = FramePropagator::new(1, 0, 1);
+            fp.x_frames.set((0, 0), x);
+            fp.z_frames.set((0, 0), z);
+            gate(&mut fp, 0);
+            out[i] = (fp.x_frames.get((0, 0)), fp.z_frames.get((0, 0)));
+        }
+        out
+    }
+
+    #[test]
+    fn test_s_gate_conjugation() {
+        // S: X → Y, Z → Z, Y → X   (bit map (x, z) -> (x, z ^ x)).
+        let [x, z, y] = single_qubit_frame_map(FramePropagator::apply_s);
+        assert_eq!(x, (true, true), "S X S† = Y");
+        assert_eq!(z, (false, true), "S Z S† = Z");
+        assert_eq!(y, (true, false), "S Y S† = X (mod phase)");
+    }
+
+    #[test]
+    fn test_sqrt_x_gate_conjugation() {
+        // √X: X → X, Z → Y, Y → Z   (bit map (x, z) -> (x ^ z, z)).
+        let [x, z, y] = single_qubit_frame_map(FramePropagator::apply_sqrt_x);
+        assert_eq!(x, (true, false), "√X X √X† = X");
+        assert_eq!(z, (true, true), "√X Z √X† = Y (mod phase)");
+        assert_eq!(y, (false, true), "√X Y √X† = Z (mod phase)");
+    }
+
+    #[test]
+    fn test_hadamard_conjugation() {
+        // H: X → Z, Z → X, Y → Y.
+        let [x, z, y] = single_qubit_frame_map(FramePropagator::apply_h);
+        assert_eq!(x, (false, true), "H X H = Z");
+        assert_eq!(z, (true, false), "H Z H = X");
+        assert_eq!(y, (true, true), "H Y H = Y (mod phase)");
+    }
+
+    #[test]
+    fn test_unitary_op_dispatch_matches_gate_methods() {
+        // Guard the UnitaryOp routing so S and √X can never be swapped again.
+        assert_eq!(
+            single_qubit_frame_map(|fp, q| fp.apply_unitary_op(UnitaryOp::SqrtZ, &[q])),
+            single_qubit_frame_map(FramePropagator::apply_s),
+            "UnitaryOp::SqrtZ must route to S",
+        );
+        assert_eq!(
+            single_qubit_frame_map(|fp, q| fp.apply_unitary_op(UnitaryOp::SqrtX, &[q])),
+            single_qubit_frame_map(FramePropagator::apply_sqrt_x),
+            "UnitaryOp::SqrtX must route to √X",
+        );
+    }
+
+    /// Cross-check a hand-written single-qubit gate against paulimer's
+    /// independently-implemented `CliffordUnitary` tableau: for every basis
+    /// Pauli input the fast-path frame transform must equal the generic
+    /// `apply_clifford` transform of the equivalent Clifford. This grounds the
+    /// gate in a separate implementation rather than a hand-derived table.
+    fn assert_gate_matches_clifford(fast: impl Fn(&mut FramePropagator, QubitId), reference: &CliffordUnitary) {
+        for &(x, z) in &[(true, false), (false, true), (true, true)] {
+            let mut a = FramePropagator::new(1, 0, 1);
+            a.x_frames.set((0, 0), x);
+            a.z_frames.set((0, 0), z);
+            fast(&mut a, 0);
+
+            let mut b = FramePropagator::new(1, 0, 1);
+            b.x_frames.set((0, 0), x);
+            b.z_frames.set((0, 0), z);
+            b.apply_clifford(reference, &[0]);
+
+            assert_eq!(
+                (a.x_frames.get((0, 0)), a.z_frames.get((0, 0))),
+                (b.x_frames.get((0, 0)), b.z_frames.get((0, 0))),
+                "fast-path gate disagrees with CliffordUnitary tableau for input (x={x}, z={z})",
+            );
+        }
+    }
+
+    #[test]
+    fn test_s_matches_clifford_tableau() {
+        let mut s = CliffordUnitary::identity(1);
+        s.left_mul_root_z(0);
+        assert_gate_matches_clifford(FramePropagator::apply_s, &s);
+    }
+
+    #[test]
+    fn test_sqrt_x_matches_clifford_tableau() {
+        let mut sx = CliffordUnitary::identity(1);
+        sx.left_mul_root_x(0);
+        assert_gate_matches_clifford(FramePropagator::apply_sqrt_x, &sx);
+    }
 
     #[test]
     fn test_cnot_propagation() {

--- a/pauliverse/src/frame_propagator.rs
+++ b/pauliverse/src/frame_propagator.rs
@@ -162,11 +162,11 @@ impl FramePropagator {
 
     /// Apply CZ(a, b): X_a → X_a Z_b, X_b → Z_a X_b, Z unchanged
     pub fn apply_cz(&mut self, qubit_a: QubitId, qubit_b: QubitId) {
-        let z_b = self.z_frames.row(qubit_b);
-        self.x_frames.row_mut(qubit_a).bitxor_assign(&z_b);
+        let x_a = self.x_frames.row(qubit_a);
+        self.z_frames.row_mut(qubit_b).bitxor_assign(&x_a);
 
-        let z_a = self.z_frames.row(qubit_a);
-        self.x_frames.row_mut(qubit_b).bitxor_assign(&z_a);
+        let x_b = self.x_frames.row(qubit_b);
+        self.z_frames.row_mut(qubit_a).bitxor_assign(&x_b);
     }
 
     /// Apply SWAP(a, b): swap both X and Z rows
@@ -763,102 +763,71 @@ mod tests {
     use smallvec::smallvec;
     use std::str::FromStr;
 
-    /// Apply a single-qubit gate to each basis Pauli (X, Z, Y) and return the
-    /// resulting `(x, z)` frame bits, so gate conjugation can be checked
-    /// against the Heisenberg table.
-    fn single_qubit_frame_map(gate: impl Fn(&mut FramePropagator, QubitId)) -> [(bool, bool); 3] {
-        // Inputs: X = (1, 0), Z = (0, 1), Y = (1, 1).
-        let inputs = [(true, false), (false, true), (true, true)];
-        let mut out = [(false, false); 3];
-        for (i, &(x, z)) in inputs.iter().enumerate() {
-            let mut fp = FramePropagator::new(1, 0, 1);
-            fp.x_frames.set((0, 0), x);
-            fp.z_frames.set((0, 0), z);
-            gate(&mut fp, 0);
-            out[i] = (fp.x_frames.get((0, 0)), fp.z_frames.get((0, 0)));
-        }
-        out
-    }
+    /// Every `UnitaryOp` must transform error frames identically to paulimer's
+    /// independently-implemented `CliffordUnitary` tableau (via `apply_clifford`).
+    ///
+    /// For each gate we compare the fast-path `apply_unitary_op` against the
+    /// tableau on every Pauli generator (`X_i`, `Z_i`) of its support. The
+    /// generators fully determine a Clifford's action, so this exhaustively
+    /// guards every gate method and the `UnitaryOp` dispatch against
+    /// conjugation errors (e.g. the S/√X swap). Comparison is bit-level, i.e.
+    /// up to the global phase that both paths ignore.
+    fn assert_unitary_op_matches_clifford(op: UnitaryOp, qubit_count: usize) {
+        let support: Vec<QubitId> = (0..qubit_count).collect();
+        let mut reference = CliffordUnitary::identity(qubit_count);
+        reference.left_mul(op, &support);
 
-    #[test]
-    fn test_s_gate_conjugation() {
-        // S: X → Y, Z → Z, Y → X   (bit map (x, z) -> (x, z ^ x)).
-        let [x, z, y] = single_qubit_frame_map(FramePropagator::apply_s);
-        assert_eq!(x, (true, true), "S X S† = Y");
-        assert_eq!(z, (false, true), "S Z S† = Z");
-        assert_eq!(y, (true, false), "S Y S† = X (mod phase)");
-    }
+        for generator_qubit in 0..qubit_count {
+            for &(x, z) in &[(true, false), (false, true)] {
+                let mut fast = FramePropagator::new(qubit_count, 0, 1);
+                fast.x_frames.set((generator_qubit, 0), x);
+                fast.z_frames.set((generator_qubit, 0), z);
+                fast.apply_unitary_op(op, &support);
 
-    #[test]
-    fn test_sqrt_x_gate_conjugation() {
-        // √X: X → X, Z → Y, Y → Z   (bit map (x, z) -> (x ^ z, z)).
-        let [x, z, y] = single_qubit_frame_map(FramePropagator::apply_sqrt_x);
-        assert_eq!(x, (true, false), "√X X √X† = X");
-        assert_eq!(z, (true, true), "√X Z √X† = Y (mod phase)");
-        assert_eq!(y, (false, true), "√X Y √X† = Z (mod phase)");
-    }
+                let mut reference_prop = FramePropagator::new(qubit_count, 0, 1);
+                reference_prop.x_frames.set((generator_qubit, 0), x);
+                reference_prop.z_frames.set((generator_qubit, 0), z);
+                reference_prop.apply_clifford(&reference, &support);
 
-    #[test]
-    fn test_hadamard_conjugation() {
-        // H: X → Z, Z → X, Y → Y.
-        let [x, z, y] = single_qubit_frame_map(FramePropagator::apply_h);
-        assert_eq!(x, (false, true), "H X H = Z");
-        assert_eq!(z, (true, false), "H Z H = X");
-        assert_eq!(y, (true, true), "H Y H = Y (mod phase)");
-    }
-
-    #[test]
-    fn test_unitary_op_dispatch_matches_gate_methods() {
-        // Guard the UnitaryOp routing so S and √X can never be swapped again.
-        assert_eq!(
-            single_qubit_frame_map(|fp, q| fp.apply_unitary_op(UnitaryOp::SqrtZ, &[q])),
-            single_qubit_frame_map(FramePropagator::apply_s),
-            "UnitaryOp::SqrtZ must route to S",
-        );
-        assert_eq!(
-            single_qubit_frame_map(|fp, q| fp.apply_unitary_op(UnitaryOp::SqrtX, &[q])),
-            single_qubit_frame_map(FramePropagator::apply_sqrt_x),
-            "UnitaryOp::SqrtX must route to √X",
-        );
-    }
-
-    /// Cross-check a hand-written single-qubit gate against paulimer's
-    /// independently-implemented `CliffordUnitary` tableau: for every basis
-    /// Pauli input the fast-path frame transform must equal the generic
-    /// `apply_clifford` transform of the equivalent Clifford. This grounds the
-    /// gate in a separate implementation rather than a hand-derived table.
-    fn assert_gate_matches_clifford(fast: impl Fn(&mut FramePropagator, QubitId), reference: &CliffordUnitary) {
-        for &(x, z) in &[(true, false), (false, true), (true, true)] {
-            let mut a = FramePropagator::new(1, 0, 1);
-            a.x_frames.set((0, 0), x);
-            a.z_frames.set((0, 0), z);
-            fast(&mut a, 0);
-
-            let mut b = FramePropagator::new(1, 0, 1);
-            b.x_frames.set((0, 0), x);
-            b.z_frames.set((0, 0), z);
-            b.apply_clifford(reference, &[0]);
-
-            assert_eq!(
-                (a.x_frames.get((0, 0)), a.z_frames.get((0, 0))),
-                (b.x_frames.get((0, 0)), b.z_frames.get((0, 0))),
-                "fast-path gate disagrees with CliffordUnitary tableau for input (x={x}, z={z})",
-            );
+                for qubit in 0..qubit_count {
+                    assert_eq!(
+                        (fast.x_frames.get((qubit, 0)), fast.z_frames.get((qubit, 0))),
+                        (
+                            reference_prop.x_frames.get((qubit, 0)),
+                            reference_prop.z_frames.get((qubit, 0))
+                        ),
+                        "{op:?}: generator (x={x}, z={z}) on qubit {generator_qubit} gives wrong frame on qubit {qubit}",
+                    );
+                }
+            }
         }
     }
 
     #[test]
-    fn test_s_matches_clifford_tableau() {
-        let mut s = CliffordUnitary::identity(1);
-        s.left_mul_root_z(0);
-        assert_gate_matches_clifford(FramePropagator::apply_s, &s);
-    }
-
-    #[test]
-    fn test_sqrt_x_matches_clifford_tableau() {
-        let mut sx = CliffordUnitary::identity(1);
-        sx.left_mul_root_x(0);
-        assert_gate_matches_clifford(FramePropagator::apply_sqrt_x, &sx);
+    fn test_all_unitary_ops_match_clifford_tableau() {
+        for op in [
+            UnitaryOp::I,
+            UnitaryOp::X,
+            UnitaryOp::Y,
+            UnitaryOp::Z,
+            UnitaryOp::SqrtX,
+            UnitaryOp::SqrtXInv,
+            UnitaryOp::SqrtY,
+            UnitaryOp::SqrtYInv,
+            UnitaryOp::SqrtZ,
+            UnitaryOp::SqrtZInv,
+            UnitaryOp::Hadamard,
+        ] {
+            assert_unitary_op_matches_clifford(op, 1);
+        }
+        for op in [
+            UnitaryOp::Swap,
+            UnitaryOp::ControlledX,
+            UnitaryOp::ControlledZ,
+            UnitaryOp::PrepareBell,
+        ] {
+            assert_unitary_op_matches_clifford(op, 2);
+        }
     }
 
     #[test]

--- a/pauliverse/src/frame_propagator.rs
+++ b/pauliverse/src/frame_propagator.rs
@@ -776,22 +776,22 @@ mod tests {
 
         for generator_qubit in 0..qubit_count {
             for &(x, z) in &[(true, false), (false, true)] {
-                let mut fast = FramePropagator::new(qubit_count, 0, 1);
-                fast.x_frames.set((generator_qubit, 0), x);
-                fast.z_frames.set((generator_qubit, 0), z);
-                fast.apply_unitary_op(op, &support);
+                let mut propagator = FramePropagator::new(qubit_count, 0, 1);
+                propagator.x_frames.set((generator_qubit, 0), x);
+                propagator.z_frames.set((generator_qubit, 0), z);
+                propagator.apply_unitary_op(op, &support);
 
-                let mut reference_prop = FramePropagator::new(qubit_count, 0, 1);
-                reference_prop.x_frames.set((generator_qubit, 0), x);
-                reference_prop.z_frames.set((generator_qubit, 0), z);
-                reference_prop.apply_clifford(&reference, &support);
+                let mut reference_propagator = FramePropagator::new(qubit_count, 0, 1);
+                reference_propagator.x_frames.set((generator_qubit, 0), x);
+                reference_propagator.z_frames.set((generator_qubit, 0), z);
+                reference_propagator.apply_clifford(&reference, &support);
 
                 for qubit in 0..qubit_count {
                     assert_eq!(
-                        (fast.x_frames.get((qubit, 0)), fast.z_frames.get((qubit, 0))),
+                        (propagator.x_frames.get((qubit, 0)), propagator.z_frames.get((qubit, 0))),
                         (
-                            reference_prop.x_frames.get((qubit, 0)),
-                            reference_prop.z_frames.get((qubit, 0))
+                            reference_propagator.x_frames.get((qubit, 0)),
+                            reference_propagator.z_frames.get((qubit, 0))
                         ),
                         "{op:?}: generator (x={x}, z={z}) on qubit {generator_qubit} gives wrong frame on qubit {qubit}",
                     );

--- a/pauliverse/src/frame_propagator.rs
+++ b/pauliverse/src/frame_propagator.rs
@@ -20,10 +20,11 @@
 
 use binar::matrix::AlignedBitMatrix;
 use binar::vec::AlignedBitVec;
-use binar::{BitMatrix, Bitwise, BitwisePairMut};
+use binar::{BitMatrix, Bitwise, BitwiseMut, BitwisePairMut};
 use paulimer::UnitaryOp;
 use paulimer::clifford::CliffordUnitary;
 use paulimer::pauli::Pauli;
+use paulimer::pauli::SparsePauli;
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
@@ -35,7 +36,7 @@ use crate::sampling::GeometricSampler;
 ///
 /// Tracks accumulated Pauli errors across all shots as two bit matrices
 /// (X and Z components), propagating them through Clifford gates via conjugation.
-pub(crate) struct FramePropagator {
+pub struct FramePropagator {
     x_frames: AlignedBitMatrix,
     z_frames: AlignedBitMatrix,
     outcome_deltas: AlignedBitMatrix,
@@ -64,6 +65,11 @@ impl FramePropagator {
     /// Layout: `(n_outcomes × n_shots)` - each row is the error delta for one outcome.
     pub fn into_outcome_deltas(self) -> AlignedBitMatrix {
         self.outcome_deltas
+    }
+
+    /// Number of qubits tracked in the error frame.
+    fn qubit_count(&self) -> usize {
+        self.x_frames.shape().0
     }
 
     // ========== Anti-commutation ==========
@@ -477,7 +483,7 @@ impl FramePropagator {
     /// Callers must ensure:
     /// - `shot < self.shot_count`
     /// - All qubits in `pauli.support()` are less than `self.qubit_count()`
-    fn apply_pauli_to_shot(&mut self, shot: usize, pauli: &paulimer::pauli::SparsePauli) {
+    fn apply_pauli_to_shot(&mut self, shot: usize, pauli: &SparsePauli) {
         use paulimer::pauli::Pauli as PauliTrait;
 
         for qubit in pauli.support() {
@@ -488,6 +494,47 @@ impl FramePropagator {
                 unsafe { self.z_frames.negate_unchecked((qubit, shot)) };
             }
         }
+    }
+
+    /// Deterministically inject a Pauli into one shot's frame.
+    ///
+    /// Unlike [`Self::inject_noise`], this applies exactly `pauli` to `shot`
+    /// with no sampling, so per-shot injection can place a distinct chosen
+    /// Pauli in each shot. Combined with [`Self::into_outcome_deltas`], this
+    /// turns a single circuit pass over `n` shots into the effect of `n`
+    /// independent faults.
+    ///
+    /// # Panics
+    ///
+    /// In debug builds, panics if `shot >= self.shot_count` or a qubit in
+    /// `pauli.support()` is out of range. In release builds these bounds are
+    /// unchecked, so the caller must ensure `shot` and every support qubit are
+    /// in range; passing an out-of-range index is undefined behavior.
+    pub fn inject_pauli(&mut self, shot: usize, pauli: &SparsePauli) {
+        let qubit_count = self.qubit_count();
+        debug_assert!(shot < self.shot_count, "shot out of range");
+        for qubit in pauli.support() {
+            debug_assert!(qubit < qubit_count, "fault qubit {qubit} out of range 0..{qubit_count}");
+        }
+        self.apply_pauli_to_shot(shot, pauli);
+    }
+
+    /// Reset a qubit to a fresh stabilizer state, clearing its error frame.
+    ///
+    /// A reset discards the qubit's prior state and reprepares it, so in the
+    /// error-frame (delta-from-reference) picture the accumulated Pauli error
+    /// on that qubit becomes identity across all shots. Both the X and Z frame
+    /// components on `qubit` are zeroed. Any preceding measurement (as in
+    /// measure-and-reset) must be applied via [`Self::measure`] before this
+    /// call so its outcome delta is recorded from the pre-reset frame.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `qubit` is out of range.
+    pub fn reset_qubit(&mut self, qubit: QubitId) {
+        debug_assert!(qubit < self.qubit_count(), "reset qubit out of range");
+        self.x_frames.row_mut(qubit).clear_bits();
+        self.z_frames.row_mut(qubit).clear_bits();
     }
 
     // ========== Instruction Dispatch ==========
@@ -560,6 +607,58 @@ mod tests {
 
         assert!(propagator.x_frames.get((0, 0)), "X still on qubit 0");
         assert!(propagator.x_frames.get((1, 0)), "X propagated to qubit 1");
+    }
+
+    #[test]
+    fn test_batched_single_fault_effects_via_one_pass() {
+        // Circuit: CNOT(0 -> 1), then measure Z0, Z1. Two faults, one per shot:
+        // shot 0 = X on control before the CNOT; shot 1 = Z on the target.
+        let mut propagator = FramePropagator::new(2, 2, 2);
+
+        propagator.inject_pauli(0, &SparsePauli::from_str("X0").unwrap());
+        propagator.inject_pauli(1, &SparsePauli::from_str("Z1").unwrap());
+
+        propagator.apply_cnot(0, 1);
+        propagator.measure(&SparsePauli::from_str("Z0").unwrap());
+        propagator.measure(&SparsePauli::from_str("Z1").unwrap());
+
+        let deltas = propagator.into_outcome_deltas();
+
+        // Shot 0: X on control copies to target -> both Z measurements flip.
+        assert!(deltas.get((0, 0)), "X0 flips Z0");
+        assert!(deltas.get((1, 0)), "X0 propagates to flip Z1");
+
+        // Shot 1: Z on target commutes with both Z measurements -> no flip.
+        assert!(!deltas.get((0, 1)), "Z1 leaves Z0");
+        assert!(!deltas.get((1, 1)), "Z1 commutes with Z1");
+    }
+
+    #[test]
+    fn test_reset_clears_frame_so_z_error_does_not_survive() {
+        let mut propagator = FramePropagator::new(1, 1, 1);
+        propagator.inject_pauli(0, &SparsePauli::from_str("Z0").unwrap());
+
+        propagator.reset_qubit(0);
+        propagator.apply_h(0);
+        propagator.measure(&SparsePauli::from_str("Z0").unwrap());
+
+        let deltas = propagator.into_outcome_deltas();
+        assert!(!deltas.get((0, 0)), "Z error before reset must not survive");
+    }
+
+    #[test]
+    fn test_measure_reset_records_delta_before_clearing() {
+        let mut propagator = FramePropagator::new(1, 2, 1);
+        propagator.inject_pauli(0, &SparsePauli::from_str("X0").unwrap());
+
+        propagator.measure(&SparsePauli::from_str("Z0").unwrap());
+        propagator.reset_qubit(0);
+        propagator.apply_h(0);
+        propagator.measure(&SparsePauli::from_str("Z0").unwrap());
+
+        let deltas = propagator.into_outcome_deltas();
+        assert!(deltas.get((0, 0)), "X error flips the pre-reset measurement");
+        assert!(!deltas.get((1, 0)), "post-reset measurement is clean");
     }
 
     #[test]

--- a/pauliverse/src/lib.rs
+++ b/pauliverse/src/lib.rs
@@ -103,6 +103,7 @@ pub(crate) mod statistical_testing;
 
 pub use circuit::{Circuit, CircuitBuilder, OutcomeId, QubitId};
 pub use faulty_simulation::FaultySimulation;
+pub use frame_propagator::FramePropagator;
 pub use noise::{OutcomeCondition, PauliDistribution, PauliFault};
 pub use outcome_complete_simulation::OutcomeCompleteSimulation;
 pub use outcome_free_simulation::OutcomeFreeSimulation;


### PR DESCRIPTION
This PR merges and builds upon A. Paetznick's internal FramePropagator work.

## What

Makes `FramePropagator` a first-class, Python-exposed simulation, adds deterministic frame primitives, and fixes latent Clifford-gate bugs.

- **`FramePropagator` implements `Simulation`** (capacity-growing gate/measure methods) and is exposed to Python as `paulimer.FramePropagator`.
- **`inject_pauli(shot, pauli)`** — place an exact Pauli in one shot's frame, with no sampling. With one shot per fault, a single circuit pass over `n` shots yields each fault's syndrome as a column of `outcome_deltas`.
- **`reset_qubit(qubit)`** — clear both frame components on a qubit. In the error-frame (delta-from-reference) picture a reset reprepares the qubit, so its accumulated error becomes identity across all shots.
- **Gate fixes:** `apply_s`/`apply_sqrt_x` had their bodies swapped (S propagated errors as √X and vice versa), and `apply_cz` had X and Z swapped (a `ControlledZ` produced no Z back-action). Both fixed. Fixes #101.

## Why

Together with the existing gate methods and `outcome_deltas`, these primitives let a consumer build a batched **fault-effect table** (fault → syndrome map) from a Clifford circuit in a single pass, rather than re-simulating per fault. `inject_noise` only samples randomly, so a *deterministic* placement primitive did not exist; `reset_qubit` handles measure-and-reset circuits correctly. Exposing the propagator to Python makes the batched capability usable from analysis code.

## Scope

- **`pauliverse`**: `Simulation` impl + qubit/outcome capacity growth, the two gate fixes, `inject_pauli`/`reset_qubit`, and exhaustive gate conformance tests.
- **`paulimer` bindings**: new `PyFramePropagator`, `.pyi` stub, and Python regression tests.

No domain-specific fault-evaluation types live in pauliverse — that logic belongs to consumers.

## Notes

- `inject_pauli`'s bounds checks are unconditional `assert!`s: it is the safe public entry point over the unchecked hot-path `apply_pauli_to_shot` (used by `inject_noise`). The Python binding validates indices and raises `IndexError`.
- **Testing:** `test_all_unitary_ops_match_clifford_tableau` validates every `UnitaryOp` (all 15 variants) against paulimer's independently-implemented `CliffordUnitary` tableau on each Pauli generator of its support — this is what caught the CZ bug. Plus tests for batched single-fault effects, reset erasing a pre-reset error, measure-and-reset ordering, and the Python binding (injection, reset, S-gate correctness, out-of-range `IndexError`).
