### PR TITLE
Add Emacs major mode for .deq files

### DIFF
--- a/deq/deq/circuit/emacs-deq/.gitignore
+++ b/deq/deq/circuit/emacs-deq/.gitignore
@@ -1,0 +1,2 @@
+# Byte-compiled Emacs Lisp
+*.elc

--- a/deq/deq/circuit/emacs-deq/Makefile
+++ b/deq/deq/circuit/emacs-deq/Makefile
@@ -1,0 +1,19 @@
+EMACS ?= emacs
+EL     := deq-mode.el
+TEST   := deq-mode-tests.el
+ELC    := $(EL:.el=.elc)
+
+.PHONY: all compile test clean
+
+all: compile test
+
+compile: $(ELC)
+
+$(ELC): $(EL)
+	$(EMACS) -Q --batch -L . -f batch-byte-compile $<
+
+test:
+	$(EMACS) -Q --batch -L . -l $(TEST) -f ert-run-tests-batch-and-exit
+
+clean:
+	rm -f $(ELC)

--- a/deq/deq/circuit/emacs-deq/README.md
+++ b/deq/deq/circuit/emacs-deq/README.md
@@ -1,0 +1,77 @@
+# DEQ Language Support for Emacs
+
+A major mode for editing `.deq` quantum error correction files in GNU Emacs,
+derived from `prog-mode`. Mirrors the feature set of the VS Code extension
+in [`../vscode-deq`](../vscode-deq/).
+
+## Features
+
+- Syntax highlighting for all DEQ constructs:
+  - `CODE`, `GADGET`, `COMPOSE`, `PROGRAM` blocks
+  - `LOGICAL`, `STABILIZER` declarations with Pauli products
+  - `INPUT`, `OUTPUT`, `CHECK`, `READOUT`, `OBSERVABLE_INCLUDE`,
+    `DETECTOR`, `ERROR(prob)`, `CONDITIONAL`, `PRESELECT`, `VIRTUAL`,
+    `PROPAGATE`, `FROM`, `FLIP`, `ASSERT_EQ`
+  - Gadget applications with `IN(…)` / `OUT(…)` port bindings
+  - Embedded Stim instructions with all target types
+  - Decorators (`@Name(…)`)
+- Distinct, themable faces for each target class:
+  - `deq-pauli-face`    — `[IXYZ]N`   (e.g. `X0`)
+  - `deq-logical-face`  — `L[XYZ]N`   (e.g. `LZ3`)
+  - `deq-check-face`    — `CN`        (e.g. `C12`)
+  - `deq-readout-face`  — `RN`, `DSN`
+  - `deq-record-face`   — `rec[-N]`, `sweep[N]`
+  - `deq-decorator-face`
+- `{`-aware indentation via `syntax-ppss`; customizable through
+  `deq-indent-offset` (default `4`).
+- Imenu navigation by `CODE` / `GADGET` / `COMPOSE` / `PROGRAM` name.
+- Comment toggling (`#`), bracket matching, and `show-paren-mode` support.
+- Inherits everything from `prog-mode`: `prettify-symbols-mode`,
+  `flymake-mode`, `display-line-numbers-mode`, xref context menu, etc.
+
+## Installation
+
+### Option 1 — load directly from this directory
+
+```elisp
+(add-to-list 'load-path "/path/to/deq/deq/circuit/emacs-deq")
+(require 'deq-mode)
+```
+
+Files ending in `.deq` will automatically open in `deq-mode` thanks to the
+`auto-mode-alist` entry installed by the autoload cookie.
+
+### Option 2 — `use-package`
+
+```elisp
+(use-package deq-mode
+  :load-path "/path/to/deq/deq/circuit/emacs-deq"
+  :mode ("\\.deq\\'" . deq-mode))
+```
+
+### Optional — byte-compile
+
+```bash
+emacs -Q --batch -f batch-byte-compile deq-mode.el
+```
+
+### Optional — run the ERT test suite
+
+```bash
+make test               # or: make EMACS=/path/to/emacs test
+```
+
+24 tests cover mode activation, syntax-table parsing, font-lock face
+assignment for every target class, indentation (with custom offset),
+imenu indexing, and comment commands.
+
+## Customization
+
+| Variable             | Default | Purpose                              |
+|----------------------|---------|--------------------------------------|
+| `deq-indent-offset`  | `4`     | Number of spaces per indent level.   |
+
+All faces (`deq-pauli-face`, `deq-logical-face`, `deq-check-face`,
+`deq-readout-face`, `deq-record-face`, `deq-decorator-face`) inherit from
+standard `font-lock-*` faces and can be remapped per-theme via
+`custom-set-faces` or `face-remap-add-relative`.

--- a/deq/deq/circuit/emacs-deq/deq-mode-tests.el
+++ b/deq/deq/circuit/emacs-deq/deq-mode-tests.el
@@ -1,0 +1,214 @@
+;;; deq-mode-tests.el --- ERT tests for deq-mode -*- lexical-binding: t -*-
+
+;; Run with:
+;;   emacs -Q --batch -L . -l deq-mode-tests.el -f ert-run-tests-batch-and-exit
+
+;;; Code:
+
+(require 'ert)
+(require 'imenu)
+(require 'deq-mode)
+
+;;; ── Helpers ───────────────────────────────────────────────────────────
+
+(defmacro deq-test-with-buffer (text &rest body)
+  "Insert TEXT into a temp buffer in `deq-mode', fontify, run BODY."
+  (declare (indent 1) (debug t))
+  `(with-temp-buffer
+     (deq-mode)
+     (insert ,text)
+     (font-lock-ensure)
+     (goto-char (point-min))
+     ,@body))
+
+(defun deq-test--face-at (regexp)
+  "Search forward for REGEXP and return the face at its first character."
+  (goto-char (point-min))
+  (re-search-forward regexp)
+  (get-text-property (match-beginning 0) 'face))
+
+(defun deq-test--reindent (text)
+  "Insert TEXT in a `deq-mode' buffer, strip indentation, then re-indent it.
+Return the resulting buffer contents."
+  (with-temp-buffer
+    (deq-mode)
+    (insert text)
+    (goto-char (point-min))
+    (while (re-search-forward "^[ \t]+" nil t) (replace-match ""))
+    (indent-region (point-min) (point-max))
+    (buffer-string)))
+
+;;; ── Activation / derivation ───────────────────────────────────────────
+
+(ert-deftest deq-mode/auto-mode-alist-triggers ()
+  (with-temp-buffer
+    (let ((buffer-file-name "/tmp/example.deq"))
+      (set-auto-mode)
+      (should (eq major-mode 'deq-mode)))))
+
+(ert-deftest deq-mode/derives-from-prog-mode ()
+  (with-temp-buffer
+    (deq-mode)
+    (should (derived-mode-p 'prog-mode))))
+
+(ert-deftest deq-mode/sets-comment-syntax-vars ()
+  (with-temp-buffer
+    (deq-mode)
+    (should (equal comment-start "# "))
+    (should (string-match-p "#" comment-start-skip))))
+
+;;; ── Syntax table ──────────────────────────────────────────────────────
+
+(ert-deftest deq-mode/recognizes-line-comments ()
+  (deq-test-with-buffer "GADGET Foo {\n  # a comment\n}\n"
+    (re-search-forward "comment")
+    (should (nth 4 (syntax-ppss)))))
+
+(ert-deftest deq-mode/recognizes-strings ()
+  (deq-test-with-buffer "IMPORT \"abc.deq\"\n"
+    (re-search-forward "abc")
+    (should (nth 3 (syntax-ppss)))))
+
+(ert-deftest deq-mode/braces-form-sexps ()
+  (deq-test-with-buffer "GADGET F { X 0 }\n"
+    (re-search-forward "{")
+    (backward-char)
+    (let ((start (point)))
+      (forward-sexp)
+      (should (eq (char-before) ?\}))
+      (should (> (point) start)))))
+
+(ert-deftest deq-mode/brackets-form-sexps ()
+  (deq-test-with-buffer "CODE Foo[[2,1,3]] {}\n"
+    (re-search-forward "\\[\\[")
+    (backward-char 2)
+    (forward-sexp)
+    (should (eq (char-before) ?\])))) ;; first ] of ]]
+
+;;; ── Font-lock ─────────────────────────────────────────────────────────
+
+(ert-deftest deq-mode/fontify-definition-keyword-and-name ()
+  (deq-test-with-buffer "GADGET Foo {\n}\n"
+    (should (eq (deq-test--face-at "GADGET") 'font-lock-keyword-face))
+    (should (eq (deq-test--face-at "Foo")    'font-lock-function-name-face))))
+
+(ert-deftest deq-mode/fontify-control-keyword-import ()
+  (deq-test-with-buffer "IMPORT \"x.deq\"\n"
+    (should (eq (deq-test--face-at "IMPORT") 'font-lock-keyword-face))))
+
+(ert-deftest deq-mode/fontify-statement-keyword-readout ()
+  (deq-test-with-buffer "GADGET F {\n  READOUT R0\n}\n"
+    (should (eq (deq-test--face-at "READOUT") 'font-lock-builtin-face))))
+
+(ert-deftest deq-mode/fontify-pauli-target ()
+  (deq-test-with-buffer "GADGET F {\n  ERROR(0.1) X3 Y7 Z2\n}\n"
+    (should (eq (deq-test--face-at "X3") 'deq-pauli-face))
+    (should (eq (deq-test--face-at "Y7") 'deq-pauli-face))
+    (should (eq (deq-test--face-at "Z2") 'deq-pauli-face))))
+
+(ert-deftest deq-mode/fontify-check-target ()
+  (deq-test-with-buffer "GADGET F {\n  CHECK C0 C12\n}\n"
+    (should (eq (deq-test--face-at "C0")  'deq-check-face))
+    (should (eq (deq-test--face-at "C12") 'deq-check-face))))
+
+(ert-deftest deq-mode/fontify-readout-target ()
+  (deq-test-with-buffer "GADGET F {\n  READOUT R5\n}\n"
+    (should (eq (deq-test--face-at "R5") 'deq-readout-face))))
+
+(ert-deftest deq-mode/fontify-logical-target ()
+  (deq-test-with-buffer "GADGET F {\n  READOUT LZ3 LX1 LY2\n}\n"
+    ;; Logical pattern must win over the bare-Pauli pattern.
+    (should (eq (deq-test--face-at "LZ3") 'deq-logical-face))
+    (should (eq (deq-test--face-at "LX1") 'deq-logical-face))
+    (should (eq (deq-test--face-at "LY2") 'deq-logical-face))))
+
+(ert-deftest deq-mode/fontify-ds-target ()
+  (deq-test-with-buffer "GADGET F {\n  PROPAGATE LX0 FROM DS4\n}\n"
+    (should (eq (deq-test--face-at "DS4") 'deq-readout-face))))
+
+(ert-deftest deq-mode/fontify-record-target ()
+  (deq-test-with-buffer "GADGET F {\n  CONDITIONAL rec[-1] LX0\n}\n"
+    (should (eq (deq-test--face-at "rec\\[-1\\]") 'deq-record-face))))
+
+(ert-deftest deq-mode/fontify-decorator ()
+  (deq-test-with-buffer "@GTYPE(2)\nGADGET F {\n}\n"
+    (should (eq (deq-test--face-at "@GTYPE") 'deq-decorator-face))))
+
+(ert-deftest deq-mode/no-fontify-inside-comment ()
+  (deq-test-with-buffer "GADGET F {\n  # X0 should not be a Pauli here\n}\n"
+    (re-search-forward "X0")
+    (let ((face (get-text-property (match-beginning 0) 'face)))
+      ;; Inside a comment the face should be the comment face, not Pauli.
+      (should (or (eq face 'font-lock-comment-face)
+                  (and (listp face)
+                       (memq 'font-lock-comment-face face))))
+      (should-not (eq face 'deq-pauli-face)))))
+
+;;; ── Indentation ───────────────────────────────────────────────────────
+
+(ert-deftest deq-mode/indent-flat-gadget ()
+  (let ((expected "GADGET Foo {\n    READOUT R0\n    CHECK C0\n}\n"))
+    (should (equal (deq-test--reindent expected) expected))))
+
+(ert-deftest deq-mode/indent-nested-repeat ()
+  (let ((expected (concat
+                   "GADGET Foo {\n"
+                   "    REPEAT 3 {\n"
+                   "        CX 0 1\n"
+                   "    }\n"
+                   "}\n")))
+    (should (equal (deq-test--reindent expected) expected))))
+
+(ert-deftest deq-mode/indent-respects-custom-offset ()
+  (let ((deq-indent-offset 2)
+        (expected (concat
+                   "GADGET Foo {\n"
+                   "  REPEAT 3 {\n"
+                   "    CX 0 1\n"
+                   "  }\n"
+                   "}\n")))
+    (should (equal (deq-test--reindent expected) expected))))
+
+(ert-deftest deq-mode/indent-closing-brace-dedents ()
+  ;; A line starting with `}' should sit one level out from its body.
+  (with-temp-buffer
+    (deq-mode)
+    (insert "GADGET Foo {\n        READOUT R0\n        }\n")
+    (goto-char (point-min))
+    (forward-line 2)
+    (deq-indent-line)
+    (back-to-indentation)
+    (should (= (current-column) 0))))
+
+;;; ── Imenu ─────────────────────────────────────────────────────────────
+
+(ert-deftest deq-mode/imenu-finds-all-definition-kinds ()
+  (deq-test-with-buffer
+      (concat
+       "CODE C[[2,1]] {\n  LOGICAL X0 Z0\n}\n"
+       "GADGET G {\n}\n"
+       "COMPOSE M {\n}\n"
+       "PROGRAM P {\n}\n")
+    (let ((idx (imenu--make-index-alist)))
+      (should (assoc "Codes"    idx))
+      (should (assoc "Gadgets"  idx))
+      (should (assoc "Compose"  idx))
+      (should (assoc "Programs" idx))
+      (should (assoc "C" (cdr (assoc "Codes"    idx))))
+      (should (assoc "G" (cdr (assoc "Gadgets"  idx))))
+      (should (assoc "M" (cdr (assoc "Compose"  idx))))
+      (should (assoc "P" (cdr (assoc "Programs" idx)))))))
+
+;;; ── Comment commands ─────────────────────────────────────────────────
+
+(ert-deftest deq-mode/comment-region-uses-hash ()
+  (with-temp-buffer
+    (deq-mode)
+    (insert "CX 0 1\n")
+    (comment-region (point-min) (point-max))
+    (goto-char (point-min))
+    (should (looking-at "#"))))
+
+(provide 'deq-mode-tests)
+
+;;; deq-mode-tests.el ends here

--- a/deq/deq/circuit/emacs-deq/deq-mode.el
+++ b/deq/deq/circuit/emacs-deq/deq-mode.el
@@ -1,0 +1,256 @@
+;;; deq-mode.el --- Major mode for DEQ quantum error correction files -*- lexical-binding: t -*-
+
+;; Copyright (C) 2026 Microsoft
+
+;; Keywords: languages, quantum
+;; Package-Requires: ((emacs "27.1"))
+;; Version: 0.1.0
+
+;; This file is not part of GNU Emacs.
+
+;;; Commentary:
+
+;; Major mode for editing `.deq' files — the source DSL for the DEQ
+;; quantum error correction system.  Features:
+;;
+;;   * Syntax highlighting for all DEQ constructs (CODE, GADGET,
+;;     COMPOSE, PROGRAM blocks; LOGICAL/STABILIZER declarations;
+;;     INPUT/OUTPUT ports; READOUT/CHECK/ERROR/CONDITIONAL statements;
+;;     embedded Stim instructions; decorators).
+;;   * Distinct faces for the four target classes (Pauli, check,
+;;     readout, logical Pauli shortcut) mirroring the VS Code
+;;     extension's color scheme.
+;;   * `{}'-aware indentation built on `syntax-ppss'.
+;;   * Imenu navigation for CODE / GADGET / COMPOSE / PROGRAM names.
+;;   * Auto-registers for files ending in `.deq'.
+;;
+;; Install:
+;;
+;;   (add-to-list 'load-path "/path/to/emacs-deq")
+;;   (require 'deq-mode)
+
+;;; Code:
+
+(require 'prog-mode)
+
+(defgroup deq nil
+  "Major mode for DEQ quantum error correction files."
+  :group 'languages
+  :prefix "deq-")
+
+(defcustom deq-indent-offset 4
+  "Number of spaces per indentation level in `deq-mode'."
+  :type 'integer
+  :safe #'integerp
+  :group 'deq)
+
+;;; ── Faces ─────────────────────────────────────────────────────────────
+
+(defface deq-pauli-face
+  '((t :inherit font-lock-type-face))
+  "Face for Pauli operators (e.g. `X0', `Y3', `Z7', `I2')."
+  :group 'deq)
+
+(defface deq-logical-face
+  '((t :inherit font-lock-function-name-face))
+  "Face for logical-Pauli shortcut targets (e.g. `LX0', `LY3', `LZ7')."
+  :group 'deq)
+
+(defface deq-check-face
+  '((t :inherit font-lock-constant-face))
+  "Face for check/detector targets (e.g. `C0', `C12')."
+  :group 'deq)
+
+(defface deq-readout-face
+  '((t :inherit font-lock-variable-name-face))
+  "Face for readout and detector-state targets (e.g. `R0', `DS3')."
+  :group 'deq)
+
+(defface deq-record-face
+  '((t :inherit font-lock-variable-name-face))
+  "Face for measurement-record and sweep-bit targets (e.g. `rec[-1]', `sweep[2]')."
+  :group 'deq)
+
+(defface deq-decorator-face
+  '((t :inherit font-lock-preprocessor-face))
+  "Face for decorators (e.g. `@GTYPE(2)')."
+  :group 'deq)
+
+;;; ── Keyword sets ──────────────────────────────────────────────────────
+
+(defconst deq--definition-keywords
+  '("CODE" "GADGET" "COMPOSE" "PROGRAM")
+  "Top-level definition keywords that introduce a named block.")
+
+(defconst deq--control-keywords
+  '("IMPORT" "REPEAT")
+  "Control-flow / file-level keywords.")
+
+(defconst deq--statement-keywords
+  '("INPUT" "OUTPUT"
+    "LOGICAL" "STABILIZER"
+    "READOUT" "OBSERVABLE_INCLUDE"
+    "CHECK" "DETECTOR"
+    "ERROR"
+    "CONDITIONAL" "PRESELECT"
+    "VIRTUAL" "PROPAGATE" "FROM" "FLIP"
+    "ASSERT_EQ"
+    "IN" "OUT")
+  "Body-statement keywords used inside definitions.")
+
+;;; ── Font-lock ─────────────────────────────────────────────────────────
+
+(defconst deq-font-lock-keywords
+  (let ((ctrl    (regexp-opt deq--control-keywords    'symbols))
+        (stmts   (regexp-opt deq--statement-keywords  'symbols))
+        (ident   "[A-Za-z][A-Za-z0-9_]*"))
+    `(
+      ;; Decorators: @Name (arguments highlighted normally).
+      ("@[A-Za-z][A-Za-z0-9_]*" 0 'deq-decorator-face)
+
+      ;; Definition introducers and their names:  CODE Foo / GADGET Foo / ...
+      (,(concat "\\b\\(" (regexp-opt deq--definition-keywords) "\\)"
+                "\\s-+\\(" ident "\\)")
+       (1 font-lock-keyword-face)
+       (2 font-lock-function-name-face))
+
+      ;; Other control / statement keywords.
+      (,ctrl  1 font-lock-keyword-face)
+      (,stmts 1 font-lock-builtin-face)
+
+      ;; Inverted-target prefix `!' (used before qubits or Paulis).
+      ("!" 0 font-lock-negation-char-face)
+
+      ;; QEC-specific targets — order matters: more specific first.
+      ("\\<L[XYZ][0-9]+\\>"   0 'deq-logical-face)
+      ("\\<DS[0-9]+\\>"       0 'deq-readout-face)
+      ("\\<C[0-9]+\\>"        0 'deq-check-face)
+      ("\\<R[0-9]+\\>"        0 'deq-readout-face)
+      ("\\<[IXYZ][0-9]+\\>"   0 'deq-pauli-face)
+
+      ;; Measurement record / sweep bit.
+      ("rec\\[-[0-9]+\\]"     0 'deq-record-face)
+      ("sweep\\[[0-9]+\\]"    0 'deq-record-face)
+
+      ;; Numbers (integers and floats, with optional sign / exponent).
+      ("\\_<-?\\(?:[0-9]+\\.?[0-9]*\\|\\.[0-9]+\\)\\(?:[eE][+-]?[0-9]+\\)?\\_>"
+       0 font-lock-constant-face)))
+  "Font-lock keywords for `deq-mode'.")
+
+;;; ── Syntax table ──────────────────────────────────────────────────────
+
+(defvar deq-mode-syntax-table
+  (let ((st (make-syntax-table)))
+    ;; `#' begins a line comment that ends at newline.
+    (modify-syntax-entry ?#  "<"  st)
+    (modify-syntax-entry ?\n ">"  st)
+    ;; Identifiers may contain `_'.
+    (modify-syntax-entry ?_  "w"  st)
+    ;; Double-quoted strings.
+    (modify-syntax-entry ?\" "\"" st)
+    ;; Matched brackets — enables `forward-sexp', `show-paren-mode',
+    ;; and `syntax-ppss' depth tracking used by the indenter.
+    (modify-syntax-entry ?\( "()" st)
+    (modify-syntax-entry ?\) ")(" st)
+    (modify-syntax-entry ?\[ "(]" st)
+    (modify-syntax-entry ?\] ")[" st)
+    (modify-syntax-entry ?\{ "(}" st)
+    (modify-syntax-entry ?\} "){" st)
+    ;; `!' and `@' are punctuation, not word constituents — keeps
+    ;; `forward-word' from absorbing them into adjacent identifiers.
+    (modify-syntax-entry ?!  "."  st)
+    (modify-syntax-entry ?@  "."  st)
+    ;; `*' as punctuation (combiner in pauli products and stim targets).
+    (modify-syntax-entry ?*  "."  st)
+    st)
+  "Syntax table for `deq-mode'.")
+
+;;; ── Indentation ───────────────────────────────────────────────────────
+
+(defun deq--paren-depth-at-bol ()
+  "Return the unbalanced paren nesting depth at the start of the current line."
+  (save-excursion
+    (beginning-of-line)
+    (car (syntax-ppss))))
+
+(defun deq--line-starts-with-closer-p ()
+  "Non-nil if the first non-whitespace char of the line is a closing bracket."
+  (save-excursion
+    (beginning-of-line)
+    (skip-chars-forward " \t")
+    (memq (char-after) '(?\} ?\) ?\]))))
+
+(defun deq-indent-line ()
+  "Indent the current line of DEQ source.
+
+Uses `syntax-ppss' to compute the `{'/`('/`[' nesting depth at the
+beginning of the line and indents to `depth * deq-indent-offset'.
+Lines whose first non-whitespace character is a closer (`}', `)',
+or `]') are dedented one level so they line up with their opener."
+  (interactive)
+  (let* ((depth   (deq--paren-depth-at-bol))
+         (closer  (deq--line-starts-with-closer-p))
+         (target  (* (max 0 (if closer (1- depth) depth))
+                     deq-indent-offset))
+         (at-or-before-text
+          (<= (current-column) (current-indentation))))
+    (if at-or-before-text
+        (indent-line-to target)
+      (save-excursion (indent-line-to target)))))
+
+;;; ── Imenu ─────────────────────────────────────────────────────────────
+
+(defconst deq-imenu-generic-expression
+  (let ((ident "\\([A-Za-z][A-Za-z0-9_]*\\)"))
+    `(("Codes"    ,(concat "^\\s-*CODE\\s-+"    ident) 1)
+      ("Gadgets"  ,(concat "^\\s-*GADGET\\s-+"  ident) 1)
+      ("Compose"  ,(concat "^\\s-*COMPOSE\\s-+" ident) 1)
+      ("Programs" ,(concat "^\\s-*PROGRAM\\s-+" ident) 1)))
+  "Imenu patterns for navigating DEQ definitions.")
+
+;;; ── Mode definition ───────────────────────────────────────────────────
+
+;;;###autoload
+(define-derived-mode deq-mode prog-mode "DEQ"
+  "Major mode for editing DEQ quantum error correction source files.
+
+\\{deq-mode-map}"
+  :syntax-table deq-mode-syntax-table
+  :group 'deq
+  (setq-local comment-start      "# ")
+  (setq-local comment-start-skip "#+\\s-*")
+  (setq-local comment-end        "")
+  (setq-local comment-use-syntax t)
+  (setq-local font-lock-defaults '(deq-font-lock-keywords))
+  (setq-local indent-line-function #'deq-indent-line)
+  (setq-local indent-tabs-mode nil)
+  (setq-local imenu-generic-expression deq-imenu-generic-expression)
+  (setq-local beginning-of-defun-function #'deq-beginning-of-defun)
+  (setq-local end-of-defun-function       #'deq-end-of-defun))
+
+(defconst deq--defun-start-regexp
+  (concat "^\\(?:@[A-Za-z][A-Za-z0-9_]*[^\n]*\n\\s-*\\)*"
+          "\\(?:CODE\\|GADGET\\|COMPOSE\\|PROGRAM\\)\\_>")
+  "Regexp matching the start of a top-level DEQ definition (allowing decorators).")
+
+(defun deq-beginning-of-defun (&optional arg)
+  "Move backward to the beginning of the enclosing DEQ definition.
+With ARG, repeat that many times (or forward if ARG is negative)."
+  (let ((arg (or arg 1)))
+    (if (> arg 0)
+        (re-search-backward deq--defun-start-regexp nil 'move arg)
+      (re-search-forward deq--defun-start-regexp nil 'move (- arg)))))
+
+(defun deq-end-of-defun ()
+  "Move to the end of the current DEQ definition.
+Assumes point is on or before the opening `{' of the definition."
+  (when (re-search-forward "{" nil 'move)
+    (backward-char)
+    (condition-case nil (forward-sexp) (scan-error nil))))
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.deq\\'" . deq-mode))
+
+(provide 'deq-mode)
+
+;;; deq-mode.el ends here

--- a/deq/documents/tutorial/chapters/language-basics.md
+++ b/deq/documents/tutorial/chapters/language-basics.md
@@ -40,17 +40,32 @@ This chapter walks through the language from the simplest example to the full fe
 
 ## Setting Up: Syntax Highlighting
 
-Before writing `.deq` files, install the VS Code syntax highlighting extension. It makes
-`.deq` files much more readable — keywords, Pauli operators, measurement references, and
-code parameters are all color-coded.
+Before writing `.deq` files, install a syntax-highlighting extension for your editor.
+It makes `.deq` files much more readable — keywords, Pauli operators, measurement
+references, and code parameters are all color-coded.
 
-**Install via Makefile:**
+### VS Code
+
+Install via the top-level Makefile:
+
 ```sh
 make install-extension
 ```
 
 After installation, any `.deq` file opened in VS Code will have syntax highlighting
 automatically.
+
+### Emacs
+
+Install by:
+
+```elisp
+(use-package deq-mode
+  :load-path "/path/to/deq/deq/circuit/emacs-deq"
+  :mode ("\\.deq\\'" . deq-mode))
+```
+
+Any file ending in `.deq` will then open in `deq-mode` automatically.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds an Emacs major mode (`deq-mode`) for editing `.deq` files, under `deq/deq/circuit/emacs-deq/`.
It mirrors the feature set of the existing VS Code extension at `deq/deq/circuit/vscode-deq/`, 
giving Emacs users the same syntax highlighting and navigation.

## What's included

- **`deq-mode.el`** — a `prog-mode`-derived major mode:
  - Syntax highlighting for all DEQ constructs (CODE/GADGET/COMPOSE/PROGRAM
    blocks, LOGICAL/STABILIZER, INPUT/OUTPUT ports,
    READOUT/CHECK/ERROR/CONDITIONAL/PRESELECT/VIRTUAL/PROPAGATE/ASSERT_EQ,
    embedded Stim instructions, `@decorators`).
  - Distinct, themable faces per target class (Pauli, logical Pauli, check,
    readout/DS, measurement record, decorator) matching the VS Code color
    scheme.
  - `{`-aware indentation via `syntax-ppss`, customizable through
    `deq-indent-offset` (default 4).
  - Imenu navigation and `beginning-of-defun`/`end-of-defun` over top-level
    definitions.
  - Comment toggling (`#`), bracket matching, and `auto-mode-alist`
    registration for `.deq`.
- **`deq-mode-tests.el`** — 24 ERT tests (activation, syntax table, font-lock,
  indentation, imenu, comments).
- **`Makefile`** — `compile`/`test`/`clean` targets (honors `EMACS=`).
- **`README.md`** — installation and customization reference.
- Tutorial: added an **Emacs** subsection to "Setting Up: Syntax Highlighting"
  in `language-basics.md`, alongside the VS Code instructions.

## Testing

- Byte-compiles cleanly under Emacs 30.2, zero warnings; `checkdoc` clean.
- `make test` → 24/24 ERT tests pass.

## Notes

- No new runtime/build dependencies; the mode requires only Emacs >= 27.1.