### PR TITLE
Fix clippy lints introduced by Rust 1.97 stable

### DIFF
--- a/binar/src/matrix/aligned_bitmatrix.rs
+++ b/binar/src/matrix/aligned_bitmatrix.rs
@@ -428,7 +428,7 @@ impl AlignedBitMatrix {
 
     fn rows_of(blocks: &mut [BitBlock], row_count: usize) -> Vec<*mut BitBlock> {
         let mut rows = Vec::<*mut BitBlock>::new();
-        let rowstride = if row_count == 0 { 0 } else { blocks.len() / row_count };
+        let rowstride = blocks.len().checked_div(row_count).unwrap_or(0);
         if rowstride == 0 {
             rows = vec![blocks.as_mut_ptr(); row_count];
         } else {
@@ -811,9 +811,9 @@ impl AlignedBitMatrix {
     ///
     /// Will panic if matrix is not invertible
     pub fn inverted(&self) -> AlignedBitMatrix {
-        assert!(self.column_count() == self.row_count());
+        assert_eq!(self.column_count(), self.row_count());
         let echelon_form = EchelonForm::new(self.clone());
-        assert!(echelon_form.pivots.len() == self.row_count());
+        assert_eq!(echelon_form.pivots.len(), self.row_count());
         debug_assert_eq!(
             self * &echelon_form.transform,
             AlignedBitMatrix::identity(self.row_count())

--- a/binar/src/matrix/bitmatrix.rs
+++ b/binar/src/matrix/bitmatrix.rs
@@ -110,19 +110,16 @@ impl EchelonForm {
     }
 
     /// Returns the reduced row echelon form matrix.
-    #[must_use]
     pub fn matrix(&self) -> BitMatrix {
         self.aligned.matrix.clone().into()
     }
 
     /// Returns the transformation matrix T such that T * original = RREF.
-    #[must_use]
     pub fn transform(&self) -> BitMatrix {
         self.aligned.transform.clone().into()
     }
 
     /// Returns the inverse transpose of the transformation matrix.
-    #[must_use]
     pub fn transform_inv_t(&self) -> BitMatrix {
         self.aligned.transform_inv_t.clone().into()
     }
@@ -842,7 +839,7 @@ impl BitMatrix {
     ///
     /// Panics if `left.len() != self.row_count()`.
     pub fn right_multiply(&self, left: &BitView) -> BitVec {
-        assert!(left.len() == self.row_count());
+        assert_eq!(left.len(), self.row_count());
         BitVec::from_aligned(self.column_count(), self.aligned.right_multiply(&left.bits))
     }
 
@@ -988,7 +985,7 @@ impl Mul<&BitView<'_>> for &BitMatrix {
     type Output = BitVec;
 
     fn mul(self, right: &BitView) -> Self::Output {
-        assert!(right.len() == self.column_count());
+        assert_eq!(right.len(), self.column_count());
         BitVec::from_aligned(self.row_count(), &self.aligned * &right.bits)
     }
 }

--- a/paulimer/src/clifford/clifford_impl.rs
+++ b/paulimer/src/clifford/clifford_impl.rs
@@ -1375,7 +1375,7 @@ impl<const WORD_COUNT: usize, const QUBIT_COUNT: usize> MutablePreImages
 
     #[allow(clippy::similar_names)]
     fn preimage_xz_views_mut_distinct(&mut self, index: (usize, usize)) -> crate::Tuple2x2<Self::PreImageViewMut<'_>> {
-        debug_assert!(index.0 != index.1);
+        debug_assert_ne!(index.0, index.1);
         unsafe {
             let (xx, xz, zx, zz) = get_quad_mut_unsafe(&mut self.preimages);
             let (xx0, xx1) = get_tuple_mut_unsafe(xx, index);

--- a/paulimer/src/clifford/generic_algos.rs
+++ b/paulimer/src/clifford/generic_algos.rs
@@ -303,7 +303,7 @@ where
     for<'life> <CliffordLike as MutablePreImages>::PreImageViewMut<'life>:
         PauliBinaryOps<<CliffordLike as Clifford>::DensePauli>,
 {
-    assert!(left.num_qubits() == right.num_qubits());
+    assert_eq!(left.num_qubits(), right.num_qubits());
     let mut result = CliffordLike::zero(left.num_qubits());
     for qubit_index in 0..left.num_qubits() {
         result

--- a/paulimer/tests/clifford_test.rs
+++ b/paulimer/tests/clifford_test.rs
@@ -290,8 +290,8 @@ proptest! {
             let z_image = clifford.image(z);
             let x_image_preimage = clifford.preimage(&x_image);
             let z_image_preimage = clifford.preimage(&z_image);
-            assert!( x == x_image_preimage);
-            assert!( z == z_image_preimage);
+            assert_eq!( x, x_image_preimage);
+            assert_eq!( z, z_image_preimage);
         }
     }
 
@@ -857,8 +857,8 @@ fn root_y_inv_images(q: usize) -> ImageTable {
 fn check_images<CliffordLike: TestableClifford>(c: &CliffordLike, image_table: &ImageTable) {
     let sparse = sparse::<CliffordLike>;
     for (p, im_p) in image_table {
-        assert!(c.image(&sparse(p)) == im_p.as_slice());
-        assert!(c.preimage(&sparse(im_p)) == p.as_slice());
+        assert_eq!(c.image(&sparse(p)), im_p.as_slice());
+        assert_eq!(c.preimage(&sparse(im_p)), p.as_slice());
     }
 }
 
@@ -907,8 +907,8 @@ fn assert_identity_on(c: &impl Clifford, qubit_index: usize) {
 fn generic_prepare_bell_states_test<CliffordLike: TestableClifford>() {
     let c = clifford_to_prepare_bell_states::<CliffordLike>(1);
     assert!(c.is_valid());
-    assert!(c.image_z(0) == [x(0), x(1)].borrow());
-    assert!(c.image_z(1) == [z(0), z(1)].borrow());
+    assert_eq!(c.image_z(0), [x(0), x(1)].borrow());
+    assert_eq!(c.image_z(1), [z(0), z(1)].borrow());
 }
 
 #[test]
@@ -997,10 +997,10 @@ fn assert_images_consistent<CliffordLike: TestableClifford>(clifford: &CliffordL
     for qubit_index in clifford.qubits() {
         let im_x = clifford.image_x(qubit_index);
         let im_z = clifford.image_z(qubit_index);
-        assert!(clifford.image_x_bits(&IndexSet::singleton(qubit_index)) == im_x);
-        assert!(clifford.image_z_bits(&IndexSet::singleton(qubit_index)) == im_z);
-        assert!(clifford.image(&sparse(&[x(qubit_index)])) == im_x);
-        assert!(clifford.image(&sparse(&[z(qubit_index)])) == im_z);
+        assert_eq!(clifford.image_x_bits(&IndexSet::singleton(qubit_index)), im_x);
+        assert_eq!(clifford.image_z_bits(&IndexSet::singleton(qubit_index)), im_z);
+        assert_eq!(clifford.image(&sparse(&[x(qubit_index)])), im_x);
+        assert_eq!(clifford.image(&sparse(&[z(qubit_index)])), im_z);
     }
 }
 
@@ -1009,10 +1009,10 @@ fn assert_preimages_consistent<CliffordLike: TestableClifford>(clifford: &Cliffo
     for qubit_index in clifford.qubits() {
         let pre_im_x = clifford.preimage_x(qubit_index);
         let pre_im_z = clifford.preimage_z(qubit_index);
-        assert!(clifford.preimage_x_bits(&IndexSet::singleton(qubit_index)) == pre_im_x);
-        assert!(clifford.preimage_z_bits(&IndexSet::singleton(qubit_index)) == pre_im_z);
-        assert!(clifford.preimage(&sparse(&[x(qubit_index)])) == pre_im_x);
-        assert!(clifford.preimage(&sparse(&[z(qubit_index)])) == pre_im_z);
+        assert_eq!(clifford.preimage_x_bits(&IndexSet::singleton(qubit_index)), pre_im_x);
+        assert_eq!(clifford.preimage_z_bits(&IndexSet::singleton(qubit_index)), pre_im_z);
+        assert_eq!(clifford.preimage(&sparse(&[x(qubit_index)])), pre_im_x);
+        assert_eq!(clifford.preimage(&sparse(&[z(qubit_index)])), pre_im_z);
     }
 }
 
@@ -1064,7 +1064,7 @@ fn compare_clifford_transformations<CliffordLike: TestableClifford>(
     apply_transformation2(&mut c2);
     assert!(c1.is_valid());
     assert!(c2.is_valid());
-    assert!(c1 == c2);
+    assert_eq!(c1, c2);
 }
 
 fn sparse<CliffordLike: TestableClifford>(
@@ -1170,7 +1170,7 @@ fn generic_random_tensor_test<CliffordLike: TestableClifford>(num_qubits1: usize
     let id2 = CliffordLike::identity(num_qubits2);
     let r1 = CliffordLike::random(num_qubits1, &mut rand::rng());
     let r2 = CliffordLike::random(num_qubits2, &mut rand::rng());
-    assert!((r1.tensor(&id2)).multiply_with(&(id1.tensor(&r2))) == r1.tensor(&r2));
+    assert_eq!((r1.tensor(&id2)).multiply_with(&(id1.tensor(&r2))), r1.tensor(&r2));
 }
 
 fn generic_tensor_test<CliffordLike: TestableClifford>() {
@@ -1181,7 +1181,7 @@ fn generic_tensor_test<CliffordLike: TestableClifford>() {
     let mut c1xc2 = CliffordLike::identity(4);
     c1xc2.left_mul_cx(0, 1);
     c1xc2.left_mul_cz(2, 3);
-    assert!(c1xc2 == c1.tensor(&c2));
+    assert_eq!(c1xc2, c1.tensor(&c2));
 
     for _ in 0..10 {
         generic_random_tensor_test::<CliffordLike>(5, 10);
@@ -1230,12 +1230,12 @@ fn css_clifford_test() {
             assert!(c.is_valid());
             for k in c.qubits() {
                 assert!(c.preimage_z(k).x_bits().is_zero());
-                assert!(c.preimage_z(k).z_bits() == &a_inv_t.row(k));
+                assert_eq!(c.preimage_z(k).z_bits(), &a_inv_t.row(k));
                 assert!(c.image_z(k).x_bits().is_zero());
                 assert!(are_bits_equal_to_col(c.image_z(k).z_bits(), &a, k));
 
                 assert!(c.preimage_x(k).z_bits().is_zero());
-                assert!(c.preimage_x(k).x_bits() == &a.row(k));
+                assert_eq!(c.preimage_x(k).x_bits(), &a.row(k));
                 assert!(c.image_x(k).z_bits().is_zero());
                 assert!(are_bits_equal_to_col(c.image_x(k).x_bits(), &a_inv_t, k));
             }

--- a/paulimer/tests/pauli_group_test.rs
+++ b/paulimer/tests/pauli_group_test.rs
@@ -20,7 +20,7 @@ fn sparse_pauli(max_weight: usize) -> BoxedStrategy<SparsePauli> {
                 let mut x_bits = IndexSet::new();
                 let mut z_bits = IndexSet::new();
 
-                for (idx, op) in indices.into_iter().zip(operators.into_iter()) {
+                for (idx, op) in indices.into_iter().zip(operators) {
                     match op {
                         'X' => x_bits.assign_index(idx, true),
                         'Z' => z_bits.assign_index(idx, true),

--- a/paulimer/tests/pauli_test.rs
+++ b/paulimer/tests/pauli_test.rs
@@ -181,7 +181,7 @@ fn pauli_product_test() {
     preimage_view.mul_assign_right(&target);
     println!("{preimage_view}");
     preimage_view.mul_assign_left(&control);
-    assert!(preimage_view == preimage_r);
+    assert_eq!(preimage_view, preimage_r);
 }
 
 fn test_round_trip<PauliLike: Pauli + FromStr<Err: fmt::Debug> + Eq + fmt::Debug + fmt::Display>(

--- a/paulimer/tests/serde_test.rs
+++ b/paulimer/tests/serde_test.rs
@@ -28,7 +28,7 @@ mod serde_tests {
                 let mut x_bits = IndexSet::new();
                 let mut z_bits = IndexSet::new();
 
-                for (index, operator) in indices.into_iter().zip(operators.into_iter()) {
+                for (index, operator) in indices.into_iter().zip(operators) {
                     match operator {
                         'X' => x_bits.assign_index(index, true),
                         'Z' => z_bits.assign_index(index, true),


### PR DESCRIPTION
## Summary

Rust 1.97.0 (now `stable` in CI) ships a clippy that promotes several
patterns to `-D clippy::pedantic` errors. This breaks the **Check clippy
(stable only)** job on `main` for **every** open PR, independently of the
change under review (e.g. #107, which touches no Rust). This PR makes the
workspace clippy-clean again under stable 1.97.0.

## Changes (all behavior-preserving)

- **`manual_assert_eq`** — `assert!(a == b)` / `debug_assert!(a != b)`
  rewritten as `assert_eq!` / `debug_assert_ne!` across `binar` and
  `paulimer` (lib + tests).
- **`double_must_use`** — removed redundant `#[must_use]` on three
  `EchelonForm` accessors that already return the `#[must_use]`
  `BitMatrix` type.
- **`manual_checked_ops`** — manual zero guard replaced with
  `checked_div(..).unwrap_or(0)` in `aligned_bitmatrix.rs`.
- **`useless_conversion`** — dropped an explicit `.into_iter()` on the
  second argument of `zip` in two proptest generators.

Most of these were applied via `cargo clippy --fix` and reviewed by hand.

## Testing (stable 1.97.0)

- `cargo clippy --workspace --exclude deq-runtime --all-targets --all-features -- -D clippy::pedantic` → clean.
- `cargo clippy --package deq-runtime --all-targets --features "cli simulator tesseract python dylib" -- -D warnings` → clean.
- `cargo test -p binar -p paulimer` → all green.

Independent of #107; either can merge first.
