### PR TITLE
Add wheel build support linux glibc 2.35

### DIFF
--- a/.ado/publish.yaml
+++ b/.ado/publish.yaml
@@ -75,12 +75,12 @@ parameters:
     default:
       - name: linux_x86_64
         poolName: "Azure-Pipelines-DevTools-EO"
-        imageName: "ubuntu-latest"
+        imageName: "ubuntu-22.04"
         os: linux
         arch: x86_64
       - name: linux_aarch64
         poolName: "Azure-Pipelines-DevTools-ARM64-EO"
-        imageName: "azurelinux-3.0-arm64"
+        imageName: "ubuntu-22.04-arm64"
         os: linux
         arch: aarch64
       - name: mac_x86_64

--- a/.ado/stages/_platform_setup_steps.yaml
+++ b/.ado/stages/_platform_setup_steps.yaml
@@ -7,11 +7,6 @@ parameters:
     type: object
 
 steps:
-  - script: |
-      sudo tdnf install binutils glibc-devel kernel-headers patchelf gcc python3-3.12.9 python3-pip-24.2 python3-devel-3.12.9 -y
-    displayName: Install build tools and Python on Linux aarch64
-    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'), eq(variables['arch'], 'aarch64'))
-
   - ${{ if and(eq(parameters.platform.os, 'windows'), eq(parameters.platform.arch, 'aarch64')) }}:
       - pwsh: |
           Write-Host "Downloading Python 3.11.9 for Windows ARM64..."
@@ -39,11 +34,10 @@ steps:
         displayName: Install Python 3.11 on Windows ARM64
 
   - ${{ if not(and(eq(parameters.platform.os, 'windows'), eq(parameters.platform.arch, 'aarch64'))) }}:
-      - ${{ if not(and(eq(parameters.platform.os, 'linux'), eq(parameters.platform.arch, 'aarch64'))) }}:
-          - task: UsePythonVersion@0
-            inputs:
-              versionSpec: "3.11"
-            displayName: Use Python 3.11
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: "3.11"
+        displayName: Use Python 3.11
 
   - bash: |
       set -euo pipefail
@@ -60,6 +54,15 @@ steps:
         fi
       fi
       cmake --version
+
+      # patchelf: maturin may invoke it when finalizing manylinux wheels.
+      if [ "$(uname -s)" = "Linux" ] && ! command -v patchelf >/dev/null 2>&1; then
+        if command -v apt-get >/dev/null 2>&1; then
+          sudo apt-get update && sudo apt-get install -y patchelf
+        elif command -v tdnf >/dev/null 2>&1; then
+          sudo tdnf install -y patchelf
+        fi
+      fi
 
       # protoc: download directly from the protobuf GitHub release so we
       # get a known version that bundles the well-known proto sources
@@ -81,11 +84,10 @@ steps:
       mkdir -p "$PROTOC_DIR"
       echo "Downloading protoc ${PROTOC_VERSION} from ${PROTOC_URL}"
       curl -fsSL "$PROTOC_URL" -o "${PROTOC_DIR}/protoc.zip"
-      # Use Python's stdlib zipfile module rather than `unzip`: Azure
-      # Linux 3.0 images do not ship unzip by default, but a Python
-      # interpreter is already available (UsePythonVersion@0 above on
-      # most platforms; tdnf python3 on Linux aarch64). Note that the
-      # Linux aarch64 path provides only `python3`, not `python`.
+      # Use Python's stdlib zipfile module rather than `unzip`: some
+      # images do not ship unzip by default, but a Python interpreter is
+      # already available from UsePythonVersion@0 above. Prefer `python3`,
+      # falling back to `python` where only the latter is on PATH.
       PYTHON_BIN="$(command -v python3 || command -v python)"
       "$PYTHON_BIN" -m zipfile -e "${PROTOC_DIR}/protoc.zip" "$PROTOC_DIR"
       chmod +x "${PROTOC_DIR}/bin/protoc"

--- a/.ado/stages/build.yaml
+++ b/.ado/stages/build.yaml
@@ -90,17 +90,37 @@ stages:
               python3 -m venv .venv
               source .venv/bin/activate
               pip install --upgrade pip
-              pip install maturin pytest hypothesis more-itertools numpy
+              maturin_args=()
+              case "$(uname -s)" in
+                Linux)
+                  # The Linux build agents run on a glibc 2.35 baseline
+                  # (Ubuntu 22.04 on both x86_64 and aarch64), so a native
+                  # build already yields glibc-2.35-compatible wheels.
+                  # Tag them explicitly as manylinux_2_35.
+                  pip install maturin pytest hypothesis more-itertools numpy
+                  maturin_args=(--manylinux manylinux_2_35)
+                  ;;
+                Darwin)
+                  pip install maturin pytest hypothesis more-itertools numpy
+                  ;;
+                *)
+                  echo "Unsupported Unix platform: $(uname -s)" >&2
+                  exit 1
+                  ;;
+              esac
 
               for crate in binar paulimer; do
                 pushd "$crate/bindings/python"
-                maturin build --release --strip --out ../../../target/wheels
+                maturin build --release --strip "${maturin_args[@]}" --out ../../../target/wheels
                 popd
                 pip install --force-reinstall --no-deps target/wheels/${crate/-/_}*.whl
                 python -c "import ${crate/-/_}; print('${crate} imported successfully')"
                 python -m pytest "$crate/bindings/python/tests/" -v
               done
 
+              if [[ "$(uname -s)" == "Linux" ]]; then
+                ls target/wheels/*manylinux_2_35*.whl
+              fi
               ls -la target/wheels/
             displayName: Build + test binar/paulimer wheels (Unix)
             condition: ne(variables['Agent.OS'], 'Windows_NT')
@@ -198,11 +218,18 @@ stages:
                 source .venv/bin/activate
                 pip install --upgrade pip
                 pip install maturin
+                maturin_args=()
+                if [[ "$(uname -s)" == "Linux" ]]; then
+                  maturin_args=(--manylinux manylinux_2_35)
+                fi
 
                 cd deq/deq_runtime
-                maturin build --release --strip --out ../../target/wheels
+                maturin build --release --strip "${maturin_args[@]}" --out ../../target/wheels
                 cd ../..
 
+                if [[ "$(uname -s)" == "Linux" ]]; then
+                  ls target/wheels/deq_runtime-*manylinux_2_35*.whl
+                fi
                 ls -la target/wheels/
               displayName: Build deq-runtime wheel (Unix)
               condition: ne(variables['Agent.OS'], 'Windows_NT')

--- a/.ado/templates/build-wheels-steps.yaml
+++ b/.ado/templates/build-wheels-steps.yaml
@@ -12,13 +12,31 @@ steps:
   displayName: Install Rust toolchain
 
 - bash: |
-    python -m pip install --upgrade maturin
+    maturin_args=()
+    case "$(uname -s)" in
+      Linux)
+        # Linux agents run on a glibc 2.35 baseline, so a native build
+        # already yields glibc-2.35-compatible wheels; tag them manylinux_2_35.
+        python -m pip install --upgrade maturin
+        maturin_args=(--manylinux manylinux_2_35)
+        ;;
+      Darwin)
+        python -m pip install --upgrade maturin
+        ;;
+      *)
+        echo "Unsupported Unix platform: $(uname -s)" >&2
+        exit 1
+        ;;
+    esac
     mkdir -p target/wheels
     cd binar/bindings/python
-    maturin build --release --out ../../../target/wheels
+    maturin build --release "${maturin_args[@]}" --out ../../../target/wheels
     cd ../../..
     cd paulimer/bindings/python
-    maturin build --release --out ../../../target/wheels
+    maturin build --release "${maturin_args[@]}" --out ../../../target/wheels
+    if [ "$(uname -s)" = "Linux" ]; then
+      ls ../../../target/wheels/*manylinux_2_35*.whl
+    fi
   displayName: Build Python wheels (Linux/Mac)
   condition: ne( variables['Agent.OS'], 'Windows_NT')
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Linux native Python wheels are now built with a `manylinux_2_35` baseline for `binar`, `paulimer`, and `deq-runtime`, improving compatibility with glibc 2.35 systems. This is achieved by building on glibc-2.35 agents (Ubuntu 22.04 on both x86_64 and aarch64) rather than adding a build-time toolchain dependency.
+
 ## [0.1.0] - 2026-01-23
 
 ### Added


### PR DESCRIPTION
`glibc` version incompatibility can prevent installation in some systems (e.g., Ubuntu 22.04 has glibc==2.35, and it will be supported until 2027).  

This PR allows for installation in slightly older systems by supporting `glibc` 2.35.  

The main change was to build on Ubuntu for both x86 and aarch64.  Notably, the previous Linux ARM build was being performed on an `azurelinux-3.0-arm64` image -- it is unclear if there were other reasons for this choice, but Ubuntu seemed like a safe choice.

The other thing to note was that the build was being performed on `ubuntu-latest`, while now it is `ubuntu-22.04` (this is what ensures the `glibc` 2.35 compatibility).

If this is a blocker for any reason, there is a cross-compilation route where `maturin` uses `zig`, but that seemed like a bigger change.