### PR TITLE
Fix ADO pipeline

### DIFF
--- a/.ado/publish.yaml
+++ b/.ado/publish.yaml
@@ -84,7 +84,7 @@ parameters:
         arch: x86_64
       - name: linux_aarch64
         poolName: "Azure-Pipelines-DevTools-ARM64-EO"
-        imageName: "ubuntu-22.04-arm64"
+        imageName: "azurelinux-3.0-arm64"
         os: linux
         arch: aarch64
       - name: mac_x86_64

--- a/.ado/publish.yaml
+++ b/.ado/publish.yaml
@@ -30,6 +30,10 @@ parameters:
     displayName: 'Build deq-runtime wheel on all OSes (no publish; useful for cross-platform debug)'
     type: boolean
     default: false
+  - name: publishDeqDecoderAbi
+    displayName: 'Publish deq-decoder-abi (required before its first deq-runtime release)'
+    type: boolean
+    default: false
   - name: publishDeqRuntime
     displayName: 'Publish deq-runtime (Rust crate)'
     type: boolean
@@ -125,10 +129,18 @@ extends:
     - template: stages/publish_crate.yaml@self
       parameters:
         platforms: ${{ parameters.platforms }}
+        crateName: deq-decoder-abi
+        cratePath: deq/deq_decoder_abi
+        publishCrate: ${{ parameters.publishDeqDecoderAbi }}
+        dependsOn: []
+
+    - template: stages/publish_crate.yaml@self
+      parameters:
+        platforms: ${{ parameters.platforms }}
         crateName: deq-runtime
         cratePath: deq/deq_runtime
         publishCrate: ${{ parameters.publishDeqRuntime }}
-        dependsOn: []
+        dependsOn: publish_deq_decoder_abi
 
     - template: stages/publish_crate.yaml@self
       parameters:

--- a/.ado/stages/_platform_setup_steps.yaml
+++ b/.ado/stages/_platform_setup_steps.yaml
@@ -45,6 +45,43 @@ steps:
             versionSpec: "3.11"
           displayName: Use Python 3.11
 
+  - ${{ if and(eq(parameters.platform.os, 'windows'), eq(parameters.platform.arch, 'aarch64')) }}:
+      - pwsh: |
+          $ErrorActionPreference = "Stop"
+          $installDir = "$(Agent.TempDirectory)\dotnet-arm64"
+          $installScript = "$(Agent.TempDirectory)\dotnet-install.ps1"
+
+          $downloadArgs = @{
+            Uri = "https://dot.net/v1/dotnet-install.ps1"
+            OutFile = $installScript
+            MaximumRetryCount = 3
+            RetryIntervalSec = 5
+          }
+          Invoke-WebRequest @downloadArgs
+
+          $installArgs = @(
+            "-Channel", "8.0",
+            "-Quality", "GA",
+            "-Architecture", "arm64",
+            "-InstallDir", $installDir,
+            "-NoPath"
+          )
+          & $installScript @installArgs
+
+          Write-Host "##vso[task.setvariable variable=DOTNET_ROOT]$installDir"
+          Write-Host "##vso[task.prependpath]$installDir"
+
+          & "$installDir\dotnet.exe" --info
+          $runtimes = & "$installDir\dotnet.exe" --list-runtimes
+          $runtimes | Write-Host
+          if (-not ($runtimes -match '^Microsoft\.NETCore\.App 8\.')) {
+            throw "Microsoft.NETCore.App 8.x was not installed."
+          }
+          if (-not ($runtimes -match '^Microsoft\.AspNetCore\.App 8\.')) {
+            throw "Microsoft.AspNetCore.App 8.x was not installed."
+          }
+        displayName: Install .NET 8 for Windows ARM64 post-job tasks
+
   - bash: |
       set -euo pipefail
 

--- a/.ado/stages/_platform_setup_steps.yaml
+++ b/.ado/stages/_platform_setup_steps.yaml
@@ -38,6 +38,12 @@ steps:
           }
         displayName: Install Python 3.11 on Windows ARM64
 
+      - task: UseDotNet@2
+        displayName: Install .NET SDK for SBOM tool (Windows ARM64)
+        inputs:
+          packageType: sdk
+          version: "8.x"
+
   - ${{ if not(and(eq(parameters.platform.os, 'windows'), eq(parameters.platform.arch, 'aarch64'))) }}:
       - ${{ if not(and(eq(parameters.platform.os, 'linux'), eq(parameters.platform.arch, 'aarch64'))) }}:
         - task: UsePythonVersion@0

--- a/.ado/stages/_platform_setup_steps.yaml
+++ b/.ado/stages/_platform_setup_steps.yaml
@@ -7,6 +7,11 @@ parameters:
     type: object
 
 steps:
+  - script: |
+      sudo tdnf install binutils glibc-devel kernel-headers patchelf gcc python3-3.12.9 python3-pip-24.2 python3-devel-3.12.9 -y
+    displayName: Install build tools and Python on Linux aarch64
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Linux'), eq(variables['arch'], 'aarch64'))
+
   - ${{ if and(eq(parameters.platform.os, 'windows'), eq(parameters.platform.arch, 'aarch64')) }}:
       - pwsh: |
           Write-Host "Downloading Python 3.11.9 for Windows ARM64..."
@@ -34,10 +39,11 @@ steps:
         displayName: Install Python 3.11 on Windows ARM64
 
   - ${{ if not(and(eq(parameters.platform.os, 'windows'), eq(parameters.platform.arch, 'aarch64'))) }}:
-      - task: UsePythonVersion@0
-        inputs:
-          versionSpec: "3.11"
-        displayName: Use Python 3.11
+      - ${{ if not(and(eq(parameters.platform.os, 'linux'), eq(parameters.platform.arch, 'aarch64'))) }}:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: "3.11"
+          displayName: Use Python 3.11
 
   - bash: |
       set -euo pipefail

--- a/.ado/stages/_platform_setup_steps.yaml
+++ b/.ado/stages/_platform_setup_steps.yaml
@@ -59,13 +59,13 @@ steps:
           }
           Invoke-WebRequest @downloadArgs
 
-          $installArgs = @(
-            "-Channel", "8.0",
-            "-Quality", "GA",
-            "-Architecture", "arm64",
-            "-InstallDir", $installDir,
-            "-NoPath"
-          )
+          $installArgs = @{
+            Channel = "8.0"
+            Quality = "GA"
+            Architecture = "arm64"
+            InstallDir = $installDir
+            NoPath = $true
+          }
           & $installScript @installArgs
 
           Write-Host "##vso[task.setvariable variable=DOTNET_ROOT]$installDir"

--- a/.ado/stages/_platform_setup_steps.yaml
+++ b/.ado/stages/_platform_setup_steps.yaml
@@ -45,43 +45,6 @@ steps:
             versionSpec: "3.11"
           displayName: Use Python 3.11
 
-  - ${{ if and(eq(parameters.platform.os, 'windows'), eq(parameters.platform.arch, 'aarch64')) }}:
-      - pwsh: |
-          $ErrorActionPreference = "Stop"
-          $installDir = "$(Agent.TempDirectory)\dotnet-arm64"
-          $installScript = "$(Agent.TempDirectory)\dotnet-install.ps1"
-
-          $downloadArgs = @{
-            Uri = "https://dot.net/v1/dotnet-install.ps1"
-            OutFile = $installScript
-            MaximumRetryCount = 3
-            RetryIntervalSec = 5
-          }
-          Invoke-WebRequest @downloadArgs
-
-          $installArgs = @{
-            Channel = "8.0"
-            Quality = "GA"
-            Architecture = "arm64"
-            InstallDir = $installDir
-            NoPath = $true
-          }
-          & $installScript @installArgs
-
-          Write-Host "##vso[task.setvariable variable=DOTNET_ROOT]$installDir"
-          Write-Host "##vso[task.prependpath]$installDir"
-
-          & "$installDir\dotnet.exe" --info
-          $runtimes = & "$installDir\dotnet.exe" --list-runtimes
-          $runtimes | Write-Host
-          if (-not ($runtimes -match '^Microsoft\.NETCore\.App 8\.')) {
-            throw "Microsoft.NETCore.App 8.x was not installed."
-          }
-          if (-not ($runtimes -match '^Microsoft\.AspNetCore\.App 8\.')) {
-            throw "Microsoft.AspNetCore.App 8.x was not installed."
-          }
-        displayName: Install .NET 8 for Windows ARM64 post-job tasks
-
   - bash: |
       set -euo pipefail
 

--- a/.ado/stages/build.yaml
+++ b/.ado/stages/build.yaml
@@ -66,6 +66,15 @@ stages:
             parameters:
               platform: ${{ platform }}
 
+          - script: cargo install cbindgen --locked
+            displayName: Install cbindgen
+
+          # the cargo test below requires the shared library to be built first
+          - script: cargo build -p deq-decoder-reference-plugin --release
+            displayName: Build deq-decoder-reference-plugin cdylib
+            env:
+              RUSTFLAGS: $(rustflagsPortable)
+
           - script: cargo test --workspace --exclude deq-runtime --exclude binar-python --exclude paulimer-bindings --release --all-features
             displayName: Build and test all Rust crates (except deq-runtime + Python shims)
             env:

--- a/.ado/stages/build.yaml
+++ b/.ado/stages/build.yaml
@@ -106,12 +106,14 @@ stages:
               maturin_args=()
               case "$(uname -s)" in
                 Linux)
-                  # The Linux build agents run on a glibc 2.35 baseline
-                  # (Ubuntu 22.04 on both x86_64 and aarch64), so a native
-                  # build already yields glibc-2.35-compatible wheels.
-                  # Tag them explicitly as manylinux_2_35.
-                  pip install maturin pytest hypothesis more-itertools numpy
-                  maturin_args=(--manylinux manylinux_2_35)
+                  if [[ "$(uname -m)" == "aarch64" ]]; then
+                    # Azure Linux 3 uses glibc 2.38. Build against Zig's glibc 2.35
+                    pip install "maturin[zig]" pytest hypothesis more-itertools numpy
+                    maturin_args=(--zig --target aarch64-unknown-linux-gnu --compatibility manylinux_2_35)
+                  else
+                    pip install maturin pytest hypothesis more-itertools numpy
+                    maturin_args=(--compatibility manylinux_2_35)
+                  fi
                   ;;
                 Darwin)
                   pip install maturin pytest hypothesis more-itertools numpy
@@ -230,10 +232,17 @@ stages:
                 python3 -m venv .venv
                 source .venv/bin/activate
                 pip install --upgrade pip
-                pip install maturin
                 maturin_args=()
                 if [[ "$(uname -s)" == "Linux" ]]; then
-                  maturin_args=(--manylinux manylinux_2_35)
+                  if [[ "$(uname -m)" == "aarch64" ]]; then
+                    pip install "maturin[zig]"
+                    maturin_args=(--zig --target aarch64-unknown-linux-gnu --compatibility manylinux_2_35)
+                  else
+                    pip install maturin
+                    maturin_args=(--compatibility manylinux_2_35)
+                  fi
+                else
+                  pip install maturin
                 fi
 
                 cd deq/deq_runtime

--- a/.ado/stages/build.yaml
+++ b/.ado/stages/build.yaml
@@ -21,6 +21,8 @@ stages:
     # carry their own runtime `condition` below, so they get skipped when
     # only deq-runtime is being built.
     condition: or(eq(${{ parameters.buildAndTest }}, true), eq(${{ parameters.buildDeqRuntime }}, true))
+    variables:
+      PipReportOverrideBehavior: SourceCodeScan
     jobs:
     - ${{ each platform in parameters.platforms }}:
         - job: ${{ platform.name }}

--- a/.ado/stages/build.yaml
+++ b/.ado/stages/build.yaml
@@ -103,16 +103,16 @@ stages:
               python3 -m venv .venv
               source .venv/bin/activate
               pip install --upgrade pip
-              maturin_args=()
+              maturin_args=(--release --strip)
               case "$(uname -s)" in
                 Linux)
                   if [[ "$(uname -m)" == "aarch64" ]]; then
                     # Azure Linux 3 uses glibc 2.38. Build against Zig's glibc 2.35
                     pip install "maturin[zig]" pytest hypothesis more-itertools numpy
-                    maturin_args=(--zig --target aarch64-unknown-linux-gnu --compatibility manylinux_2_35)
+                    maturin_args+=(--zig --target aarch64-unknown-linux-gnu --compatibility manylinux_2_35)
                   else
                     pip install maturin pytest hypothesis more-itertools numpy
-                    maturin_args=(--compatibility manylinux_2_35)
+                    maturin_args+=(--compatibility manylinux_2_35)
                   fi
                   ;;
                 Darwin)
@@ -126,7 +126,7 @@ stages:
 
               for crate in binar paulimer; do
                 pushd "$crate/bindings/python"
-                maturin build --release --strip "${maturin_args[@]}" --out ../../../target/wheels
+                maturin build "${maturin_args[@]}" --out ../../../target/wheels
                 popd
                 pip install --force-reinstall --no-deps target/wheels/${crate/-/_}*.whl
                 python -c "import ${crate/-/_}; print('${crate} imported successfully')"
@@ -232,21 +232,21 @@ stages:
                 python3 -m venv .venv
                 source .venv/bin/activate
                 pip install --upgrade pip
-                maturin_args=()
+                maturin_args=(--release --strip)
                 if [[ "$(uname -s)" == "Linux" ]]; then
                   if [[ "$(uname -m)" == "aarch64" ]]; then
                     pip install "maturin[zig]"
-                    maturin_args=(--zig --target aarch64-unknown-linux-gnu --compatibility manylinux_2_35)
+                    maturin_args+=(--zig --target aarch64-unknown-linux-gnu --compatibility manylinux_2_35)
                   else
                     pip install maturin
-                    maturin_args=(--compatibility manylinux_2_35)
+                    maturin_args+=(--compatibility manylinux_2_35)
                   fi
                 else
                   pip install maturin
                 fi
 
                 cd deq/deq_runtime
-                maturin build --release --strip "${maturin_args[@]}" --out ../../target/wheels
+                maturin build "${maturin_args[@]}" --out ../../target/wheels
                 cd ../..
 
                 if [[ "$(uname -s)" == "Linux" ]]; then

--- a/.ado/stages/publish_crate.yaml
+++ b/.ado/stages/publish_crate.yaml
@@ -39,6 +39,8 @@ stages:
         displayName: Install Rust toolchain
 
       - script: |
+          set -euo pipefail
+
           mkdir -p target/crates
           cargo update --dry-run
           cd ${{ coalesce(parameters.cratePath, parameters.crateName) }}
@@ -68,6 +70,27 @@ stages:
           ls -la $(System.DefaultWorkingDirectory)/target/crates/
         displayName: List ${{ parameters.crateName }} .crate files
 
+      - bash: |
+          set -euo pipefail
+
+          source_dir="$(System.DefaultWorkingDirectory)/target/crates"
+          release_dir="$(Pipeline.Workspace)/esrp-release"
+          crate_files=()
+          mapfile -d '' crate_files < <(find "$source_dir" -type f -name '${{ parameters.crateName }}-*.crate' -print0)
+
+          if [[ ${#crate_files[@]} -ne 1 ]]; then
+            echo "Expected exactly one ${{ parameters.crateName }} .crate file, found ${#crate_files[@]}." >&2
+            find "$source_dir" -type f -print >&2
+            exit 1
+          fi
+
+          rm -rf "$release_dir"
+          mkdir -p "$release_dir"
+          cp "${crate_files[0]}" "$release_dir/"
+          tar -tzf "$release_dir/$(basename "${crate_files[0]}")" >/dev/null
+          ls -la "$release_dir"
+        displayName: Stage ${{ parameters.crateName }} for ESRP
+
       - task: EsrpRelease@11
         displayName: Publish ${{ parameters.crateName }} to crates.io
         inputs:
@@ -80,7 +103,7 @@ stages:
           contenttype: 'Rust'
           contentsource: 'Folder'
           domaintenantid: "975f013f-7f24-47e8-a7d3-abc4752bf346"
-          folderlocation: "$(System.DefaultWorkingDirectory)/target/crates"
+          folderlocation: "$(Pipeline.Workspace)/esrp-release"
           waitforreleasecompletion: true
           owners: "adpaetzn@microsoft.com"
           approvers: "adpaetzn@microsoft.com"

--- a/.ado/stages/publish_crate.yaml
+++ b/.ado/stages/publish_crate.yaml
@@ -68,7 +68,7 @@ stages:
           ls -la $(System.DefaultWorkingDirectory)/target/crates/
         displayName: List ${{ parameters.crateName }} .crate files
 
-      - task: EsrpRelease@10
+      - task: EsrpRelease@11
         displayName: Publish ${{ parameters.crateName }} to crates.io
         inputs:
           connectedservicename: "PME ESRP Azure Connection"

--- a/.ado/templates/build-wasm-wheels-steps.yaml
+++ b/.ado/templates/build-wasm-wheels-steps.yaml
@@ -40,8 +40,6 @@ steps:
   - bash: |
       set -euo pipefail
 
-      mkdir -p target/wheels
-
       python -m pip install --upgrade pip
       python -m pip install "pyodide-build>=0.35,<0.36"
 
@@ -76,10 +74,19 @@ steps:
       cargo --version
       rustc --version
 
-      WHEELS_OUT="$(pwd)/target/wheels"
+      # Maturin uses the Cargo target directory's `wheels` subdirectory as its
+      # internal PEP 517 output. Giving pyodide-build that same directory makes
+      # the frontend copy the wheel onto itself. Build into a separate staging
+      # directory, then collect only the finalized PyEmscripten wheels.
+      WHEELS_OUT="$(pwd)/dist"
+      rm -rf "$WHEELS_OUT"
+      mkdir -p "$WHEELS_OUT"
       for crate in binar paulimer; do
         ( cd "$crate/bindings/python" && pyodide build --outdir "$WHEELS_OUT" )
       done
 
+      rm -rf target/wheels
+      mkdir -p target/wheels
+      cp "$WHEELS_OUT"/*.whl target/wheels/
       ls -la target/wheels/
     displayName: Build binar/paulimer WASM wheels (py${{ parameters.pythonVersion }})

--- a/.ado/templates/build-wasm-wheels-steps.yaml
+++ b/.ado/templates/build-wasm-wheels-steps.yaml
@@ -25,6 +25,11 @@ steps:
     inputs:
       versionSpec: "${{ parameters.pythonVersion }}"
 
+  - task: PipAuthenticate@1
+    inputs:
+      artifactFeeds: $(pypiArtifactFeed)
+    displayName: Authenticate pip with ADO feed
+
   - bash: |
       set -euo pipefail
 

--- a/.ado/templates/build-wasm-wheels-steps.yaml
+++ b/.ado/templates/build-wasm-wheels-steps.yaml
@@ -64,10 +64,17 @@ steps:
       # shellcheck disable=SC1091
       source "$EMSDK_DIR/emsdk_env.sh"
 
-      # Rust: the Pyodide-pinned (stable) toolchain plus the Emscripten target std.
-      rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
-      rustup target add wasm32-unknown-emscripten --toolchain "$RUST_TOOLCHAIN"
+      # RustInstaller sets CARGO_HOME to a temporary directory containing the
+      # authenticated Cargo configuration. rustup itself is installed under
+      # the agent user's default Cargo home, so temporarily hide CARGO_HOME
+      # only while managing the Pyodide-pinned toolchain and target.
+      env -u CARGO_HOME rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal
+      env -u CARGO_HOME rustup target add wasm32-unknown-emscripten --toolchain "$RUST_TOOLCHAIN"
+      RUST_TOOLCHAIN_BIN="$(dirname "$(env -u CARGO_HOME rustup which --toolchain "$RUST_TOOLCHAIN" cargo)")"
+      export PATH="$RUST_TOOLCHAIN_BIN:$PATH"
       export RUSTUP_TOOLCHAIN="$RUST_TOOLCHAIN"
+      cargo --version
+      rustc --version
 
       WHEELS_OUT="$(pwd)/target/wheels"
       for crate in binar paulimer; do

--- a/.ado/templates/build-wasm-wheels-steps.yaml
+++ b/.ado/templates/build-wasm-wheels-steps.yaml
@@ -25,6 +25,13 @@ steps:
     inputs:
       versionSpec: "${{ parameters.pythonVersion }}"
 
+  - task: RustInstaller@1
+    inputs:
+      rustVersion: ms-prod-$(RUST_TOOLCHAIN_VERSION)
+      cratesIoFeedOverride: $(cratesIoFeedOverride)
+      toolchainFeed: $(toolchainFeed)
+    displayName: Configure Rust and Cargo feeds
+
   - task: PipAuthenticate@1
     inputs:
       artifactFeeds: $(pypiArtifactFeed)

--- a/.ado/templates/build-wheels-steps.yaml
+++ b/.ado/templates/build-wheels-steps.yaml
@@ -12,16 +12,16 @@ steps:
   displayName: Install Rust toolchain
 
 - bash: |
-    maturin_args=()
+    maturin_args=(--release)
     case "$(uname -s)" in
       Linux)
         if [[ "$(uname -m)" == "aarch64" ]]; then
           # Azure Linux 3 uses glibc 2.38. Build against Zig's glibc 2.35
           python -m pip install --upgrade "maturin[zig]"
-          maturin_args=(--zig --target aarch64-unknown-linux-gnu --compatibility manylinux_2_35)
+          maturin_args+=(--zig --target aarch64-unknown-linux-gnu --compatibility manylinux_2_35)
         else
           python -m pip install --upgrade maturin
-          maturin_args=(--compatibility manylinux_2_35)
+          maturin_args+=(--compatibility manylinux_2_35)
         fi
         ;;
       Darwin)
@@ -34,10 +34,10 @@ steps:
     esac
     mkdir -p target/wheels
     cd binar/bindings/python
-    maturin build --release "${maturin_args[@]}" --out ../../../target/wheels
+    maturin build "${maturin_args[@]}" --out ../../../target/wheels
     cd ../../..
     cd paulimer/bindings/python
-    maturin build --release "${maturin_args[@]}" --out ../../../target/wheels
+    maturin build "${maturin_args[@]}" --out ../../../target/wheels
     if [ "$(uname -s)" = "Linux" ]; then
       ls ../../../target/wheels/*manylinux_2_35*.whl
     fi

--- a/.ado/templates/build-wheels-steps.yaml
+++ b/.ado/templates/build-wheels-steps.yaml
@@ -15,10 +15,14 @@ steps:
     maturin_args=()
     case "$(uname -s)" in
       Linux)
-        # Linux agents run on a glibc 2.35 baseline, so a native build
-        # already yields glibc-2.35-compatible wheels; tag them manylinux_2_35.
-        python -m pip install --upgrade maturin
-        maturin_args=(--manylinux manylinux_2_35)
+        if [[ "$(uname -m)" == "aarch64" ]]; then
+          # Azure Linux 3 uses glibc 2.38. Build against Zig's glibc 2.35
+          python -m pip install --upgrade "maturin[zig]"
+          maturin_args=(--zig --target aarch64-unknown-linux-gnu --compatibility manylinux_2_35)
+        else
+          python -m pip install --upgrade maturin
+          maturin_args=(--compatibility manylinux_2_35)
+        fi
         ;;
       Darwin)
         python -m pip install --upgrade maturin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Linux native Python wheels are now built with a `manylinux_2_35` baseline for `binar`, `paulimer`, and `deq-runtime`, improving compatibility with glibc 2.35 systems. This is achieved by building on glibc-2.35 agents (Ubuntu 22.04 on both x86_64 and aarch64) rather than adding a build-time toolchain dependency.
+- Linux native Python wheels are now built with a `manylinux_2_35` baseline for `binar`, `paulimer`, and `deq-runtime`, improving compatibility with glibc 2.35 systems. The x86_64 wheels build natively on Ubuntu 22.04, while ARM64 wheels use Zig's glibc 2.35 sysroot on Azure Linux 3 agents.
 
 ## [0.1.0] - 2026-01-23
 

--- a/binar/Cargo.toml
+++ b/binar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binar"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["Microsoft Corporation"]
 description = "High-performance binary arithmetic."

--- a/binar/bindings/python/Cargo.toml
+++ b/binar/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binar-python"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["Microsoft Corporation"]
 description = "High-performance binary arithmetic."

--- a/deq/CHANGELOG.md
+++ b/deq/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+## [0.4.0] - 2026-07-16
+
+### Added
+- Lattice surgery support with joint-port observable finding
+- CONDITIONAL keyword in COMPOSE and PROGRAM for efficient logical Pauli feed-forward
+- More efficient error model construction with a shared FramePropagator
+- Basic loss simulation and decoding
+- Python async interface for direct interaction with decoding system
+- ABI for integrating decoder binary into deq-runtime

--- a/deq/deq_decoder_abi/reference_plugin/tests/header_sync.rs
+++ b/deq/deq_decoder_abi/reference_plugin/tests/header_sync.rs
@@ -41,8 +41,8 @@ fn header_matches_rust_abi() {
     let committed_text = std::fs::read_to_string(&committed).expect("read committed header");
 
     assert_eq!(
-        generated.trim_end(),
-        committed_text.trim_end(),
+        generated.replace("\r\n", "\n").trim_end(),
+        committed_text.replace("\r\n", "\n").trim_end(),
         "{} is out of sync with the Rust ABI; regenerate with reference_plugin/regenerate.sh",
         committed.display()
     );

--- a/deq/deq_runtime/Cargo.toml
+++ b/deq/deq_runtime/Cargo.toml
@@ -110,7 +110,7 @@ fastrace = { version = "0.7.14", features = ["enable"], optional = true }
 stim = { version = "0.4.1", optional = true }
 rhai = { version = "1", features = ["sync"], optional = true }
 cxx = { version = "1.0", optional = true }
-deq-decoder-abi = { path = "../deq_decoder_abi", features = ["host"], optional = true }
+deq-decoder-abi = { version = "0.1.0", path = "../deq_decoder_abi", features = ["host"], optional = true }
 
 [build-dependencies]
 tonic-prost-build = "0.14.2"

--- a/deq/deq_runtime/Cargo.toml
+++ b/deq/deq_runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deq-runtime"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2024"
 authors = ["Microsoft Corporation"]
 description = "deq: Real-time Quantum Error Correction Decoding System"

--- a/deq/pyproject.toml
+++ b/deq/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "deq"
 dynamic = []
-version = "0.3.2"
+version = "0.4.0"
 description = "deq: quantum error correction decoding system."
 readme = "README.md"
 license = { text = "MIT" }

--- a/paulimer/Cargo.toml
+++ b/paulimer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paulimer"
-version = "0.1.2"
+version = "0.2.2"
 edition = "2024"
 publish = true
 license = "MIT"

--- a/paulimer/bindings/python/Cargo.toml
+++ b/paulimer/bindings/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paulimer-bindings"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 publish = false
 

--- a/paulimer/src/pauli/generic.rs
+++ b/paulimer/src/pauli/generic.rs
@@ -1185,6 +1185,9 @@ where
 
     for character in pauli_string_without_phase.chars() {
         if let Some(digit) = get_digit(character) {
+            if pauli_char.is_none() {
+                return Err(PauliStringParsingError);
+            }
             index = index
                 .checked_mul(10)
                 .and_then(|i| i.checked_add(digit))

--- a/paulimer/tests/pauli_test.rs
+++ b/paulimer/tests/pauli_test.rs
@@ -328,6 +328,14 @@ fn sparse_parsing_with_large_qubit_index() {
     assert!(pauli.size() >= 1024);
 }
 
+#[test]
+fn sparse_parsing_rejects_digits_without_a_pauli() {
+    for invalid_pauli in ["00", "0X0"] {
+        assert!(invalid_pauli.parse::<DensePauli>().is_err());
+        assert!(invalid_pauli.parse::<SparsePauli>().is_err());
+    }
+}
+
 prop_compose! {
     fn arbitrary_projective_pauli(max_dimension: usize)(dimension in 0..max_dimension) -> DensePauliProjective {
         let pauli = arbitrary_pauli_of_length(dimension);

--- a/pauliverse/Cargo.toml
+++ b/pauliverse/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pauliverse"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 publish = true
 license = "MIT"

--- a/pauliverse/Cargo.toml
+++ b/pauliverse/Cargo.toml
@@ -19,7 +19,6 @@ derive_more = { version = "2.0.1", features = [
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 proptest = "1.0"
-statrs = "0.18"
 
 [[bench]]
 name = "simulation_benchmark"

--- a/pauliverse/Cargo.toml
+++ b/pauliverse/Cargo.toml
@@ -7,8 +7,8 @@ license = "MIT"
 description = "Fast stabilizer simulation"
 
 [dependencies]
-binar = { path = "../binar", version = "0.1.0" }
-paulimer = { path = "../paulimer", version = "0.1.0" }
+binar = { path = "../binar", version = "0.1.2" }
+paulimer = { path = "../paulimer", version = "0.2.2" }
 rand = "0.10"
 # SmallVec avoids heap allocation for small collections (1-4 elements) in hot paths
 smallvec = "1.13"


### PR DESCRIPTION
Some previous PRs break the ADO pipeline, including a missing image ubuntu-22.04-arm64 and WASM build pipelines. This PR fixes those problems so that they can build and publish.

Also bumps up the versions of binar, paulimer and deq accordingly because many of the new features in binar and paulimer are now required by deq. Current user cannot install the latest deq and use it directly.