### PR TITLE
Multiply repeated Pauli indices in _pauli_products_commute

### DIFF
--- a/deq/deq/transpiler/code_validation.py
+++ b/deq/deq/transpiler/code_validation.py
@@ -11,22 +11,31 @@ commutation relations of a valid stabilizer code:
 """
 
 
+import math
+
+from paulimer import SparsePauli
+
 from deq.circuit.model import CodeDefinition, PauliProduct
+
+_PAULI_CTORS = {"X": SparsePauli.x, "Y": SparsePauli.y, "Z": SparsePauli.z}
 
 
 def _pauli_products_commute(a: PauliProduct, b: PauliProduct) -> bool:
     """Return ``True`` if two Pauli products commute.
 
-    Two multi-qubit Pauli operators commute iff the number of qubits
-    where they have *different* non-identity Pauli types is even.
+    Terms are multiplied into a :class:`paulimer.SparsePauli` so that repeated
+    indices within a product reduce (e.g. ``X0*Z0`` collapses to ``-iY0``)
+    before the commutation test.
     """
-    map_a = {t.index: t.pauli for t in a.terms if t.pauli != "I"}
-    map_b = {t.index: t.pauli for t in b.terms if t.pauli != "I"}
-    anticommuting_count = 0
-    for q in map_a.keys() & map_b.keys():
-        if map_a[q] != map_b[q]:
-            anticommuting_count += 1
-    return anticommuting_count % 2 == 0
+
+    def to_sparse(product: PauliProduct) -> SparsePauli:
+        return math.prod(
+            (_PAULI_CTORS[term.pauli](term.index)
+             for term in product.terms if term.pauli != "I"),
+            start=SparsePauli.identity(),
+        )
+
+    return to_sparse(a).commutes_with(to_sparse(b))
 
 
 def _code_location(code: CodeDefinition) -> str:

--- a/deq/tests/transpiler/test_code_validation.py
+++ b/deq/tests/transpiler/test_code_validation.py
@@ -10,8 +10,9 @@ operator, or GADGET.
 
 import pytest
 
+from deq.circuit.model import PauliProduct, PauliTerm
 from deq.circuit.parser import parse
-from deq.transpiler.code_validation import validate_code
+from deq.transpiler.code_validation import _pauli_products_commute, validate_code
 from deq.transpiler.jit_library_builder import build_jit_library
 
 
@@ -127,3 +128,28 @@ class TestUnknownPortCodeName:
         assert "OUTPUT" in msg
         assert "'Missing'" in msg
         assert "Known CODE names" in msg
+
+
+class TestPauliProductsCommute:
+    """``_pauli_products_commute`` reduces repeated indices before comparing."""
+
+    def test_repeated_index_is_reduced(self) -> None:
+        """``X0*Z0`` equals ``-iY0`` and so commutes with ``Y0``.
+
+        The dict-based implementation kept only the last term at each index,
+        dropping ``X0`` and comparing ``Z0`` with ``Y0``, wrongly reporting
+        anticommutation.
+        """
+        x0_z0 = PauliProduct(terms=(PauliTerm("X", 0), PauliTerm("Z", 0)))
+        y0 = PauliProduct(terms=(PauliTerm("Y", 0),))
+        assert _pauli_products_commute(x0_z0, y0)
+
+    def test_disjoint_and_single_qubit_cases_unchanged(self) -> None:
+        """Products on distinct qubits and single-qubit pairs are unaffected."""
+        z0_z1 = PauliProduct(terms=(PauliTerm("Z", 0), PauliTerm("Z", 1)))
+        x0_x1 = PauliProduct(terms=(PauliTerm("X", 0), PauliTerm("X", 1)))
+        assert _pauli_products_commute(z0_z1, x0_x1)
+
+        x0 = PauliProduct(terms=(PauliTerm("X", 0),))
+        z0 = PauliProduct(terms=(PauliTerm("Z", 0),))
+        assert not _pauli_products_commute(x0, z0)


### PR DESCRIPTION
Fixes #137.

## Problem

`_pauli_products_commute` builds a `{index: pauli}` dict per product, so two non-identity terms on the same qubit collapse to the last one instead of multiplying. `X0*Z0` (= -iY0) is read as `Z0`, and the commutation test runs against the wrong operator. Consequently, it rejects valid codes and accepts invalid ones. See #137 for the full analysis and reproduction.

## Fix

Multiply each product's terms into a `paulimer.SparsePauli` (so `X0*Z0` reduces to -iY0) and use `.commutes_with()`. This reuses the same paulimer path the JIT transpiler already relies on (`_pauli_product_to_sparse`), replacing the ad-hoc dict comparison.