### PR TITLE
Fix root-Y action on identity

### DIFF
--- a/paulimer/src/clifford/clifford_impl.rs
+++ b/paulimer/src/clifford/clifford_impl.rs
@@ -2030,7 +2030,7 @@ where
             }
 
             remainder.mul_assign_left_z(non_identity_index);
-            remainder.add_assign_phase_exp(1);
+            remainder.add_assign_phase_exp(3);
 
             result.left_mul_pauli_exp(&remainder);
             for current_image in current_images.iter_mut().skip(index) {

--- a/paulimer/src/pauli/algorithms.rs
+++ b/paulimer/src/pauli/algorithms.rs
@@ -134,7 +134,7 @@ pub fn apply_root_x<PauliLike: Pauli + PauliBinaryOps>(target: &mut PauliLike, q
 }
 
 pub fn apply_root_y<PauliLike: Pauli + PauliBinaryOps>(target: &mut PauliLike, qubit_index: usize) {
-    if !(target.z_bits().index(qubit_index) & target.x_bits().index(qubit_index)) {
+    if target.z_bits().index(qubit_index) != target.x_bits().index(qubit_index) {
         target.mul_assign_left_y(qubit_index);
         target.add_assign_phase_exp(3);
     }

--- a/paulimer/src/pauli/generic.rs
+++ b/paulimer/src/pauli/generic.rs
@@ -565,14 +565,14 @@ impl<Bits: PauliBits + BitwiseMut, Exponent: PhaseExponentMutable> PauliMutable 
     fn mul_assign_right_x(&mut self, qubit_id: usize) {
         self.projective.x_bits.negate_index(qubit_id);
         if self.projective.z_bits().index(qubit_id) {
-            self.xz_phase_exponent().add_assign(2);
+            self.xz_phase_exp.add_assign(2);
         }
     }
 
     fn mul_assign_left_z(&mut self, qubit_id: usize) {
         self.projective.z_bits.negate_index(qubit_id);
         if self.x_bits().index(qubit_id) {
-            self.xz_phase_exponent().add_assign(2);
+            self.xz_phase_exp.add_assign(2);
         }
     }
 

--- a/paulimer/tests/clifford_test.rs
+++ b/paulimer/tests/clifford_test.rs
@@ -503,6 +503,16 @@ proptest! {
 
 }
 
+#[test]
+fn group_encoding_clifford_preserves_generator_sign() {
+    let generator: DensePauli = "-X".parse().unwrap();
+    let encoding_clifford = group_encoding_clifford_of(std::slice::from_ref(&generator), 1);
+    assert_eq!(
+        encoding_clifford.preimage(&generator),
+        "Z".parse::<DensePauli>().unwrap()
+    );
+}
+
 prop_compose! {
    fn arbitrary_clifford(dimension_range: Range<usize>)(dimension in dimension_range) -> CliffordUnitary {
         arbitrary_clifford_of_dimension(dimension)

--- a/paulimer/tests/pauli_test.rs
+++ b/paulimer/tests/pauli_test.rs
@@ -9,7 +9,8 @@ use paulimer::StringNotation::{Ascii, Tex, Unicode};
 use paulimer::core::{x, y, z};
 use paulimer::pauli::{
     DensePauli, DensePauliProjective, Pauli, PauliBinaryOps, PauliMutable, PauliUnitary, Phase, SparsePauli,
-    SparsePauliProjective, commutes_with, generic::PhaseExponent, indexed_anti_commutators_of, indexed_commutators_of,
+    SparsePauliProjective, apply_root_y, commutes_with, generic::PhaseExponent, indexed_anti_commutators_of,
+    indexed_commutators_of,
 };
 use proptest::prelude::*;
 
@@ -37,6 +38,13 @@ proptest! {
         let square = pauli.clone() * &pauli;
         let expect_hermitian = square.xz_phase_exponent().value() == 0;
         assert_eq!(pauli.is_order_two(), expect_hermitian);
+    }
+
+    #[test]
+    fn apply_root_y_preserves_local_identity((mut pauli, index) in pauli_with_local_identity()) {
+        let expected = pauli.clone();
+        apply_root_y(&mut pauli, index);
+        prop_assert_eq!(pauli, expected);
     }
 
     #[test]
@@ -165,6 +173,22 @@ prop_compose! {
 
 fn arbitrary_pauli_of_length(length: usize) -> PauliUnitary<Vec<bool>, u8> {
     paulimer::pauli::pauli_random(length, &mut rand::rng())
+}
+
+fn pauli_with_local_identity() -> impl Strategy<Value = (PauliUnitary<Vec<bool>, u8>, usize)> {
+    (1usize..100).prop_flat_map(|length| {
+        (
+            prop::collection::vec(any::<bool>(), length),
+            prop::collection::vec(any::<bool>(), length),
+            0u8..4,
+            0..length,
+        )
+            .prop_map(|(mut x_bits, mut z_bits, phase, index)| {
+                x_bits[index] = false;
+                z_bits[index] = false;
+                (PauliUnitary::from_bits(x_bits, z_bits, phase), index)
+            })
+    })
 }
 
 #[test]

--- a/paulimer/tests/pauli_test.rs
+++ b/paulimer/tests/pauli_test.rs
@@ -48,6 +48,36 @@ proptest! {
     }
 
     #[test]
+    fn mul_assign_right_x_matches_general_multiplication(
+        (mut pauli, index) in pauli_with_local_bits(None, None)
+    ) {
+        let mut x_bits = vec![false; pauli.x_bits().len()];
+        x_bits[index] = true;
+        let x = PauliUnitary::from_bits(x_bits, vec![false; pauli.z_bits().len()], 0u8);
+        let mut expected = pauli.clone();
+        expected.mul_assign_right(&x);
+
+        pauli.mul_assign_right_x(index);
+
+        prop_assert_eq!(pauli, expected);
+    }
+
+    #[test]
+    fn mul_assign_left_z_matches_general_multiplication(
+        (mut pauli, index) in pauli_with_local_bits(None, None)
+    ) {
+        let mut z_bits = vec![false; pauli.z_bits().len()];
+        z_bits[index] = true;
+        let z = PauliUnitary::from_bits(vec![false; pauli.x_bits().len()], z_bits, 0u8);
+        let mut expected = pauli.clone();
+        expected.mul_assign_left(&z);
+
+        pauli.mul_assign_left_z(index);
+
+        prop_assert_eq!(pauli, expected);
+    }
+
+    #[test]
     fn commutes_with_matches_explicit_commutator((left, right) in equal_length_paulis(1)) {
         let leftright = left.clone() * &right;
         let rightleft = right.clone() * &left;
@@ -176,16 +206,27 @@ fn arbitrary_pauli_of_length(length: usize) -> PauliUnitary<Vec<bool>, u8> {
 }
 
 fn pauli_with_local_identity() -> impl Strategy<Value = (PauliUnitary<Vec<bool>, u8>, usize)> {
-    (1usize..100).prop_flat_map(|length| {
+    pauli_with_local_bits(Some(false), Some(false))
+}
+
+fn pauli_with_local_bits(
+    local_x: Option<bool>,
+    local_z: Option<bool>,
+) -> impl Strategy<Value = (PauliUnitary<Vec<bool>, u8>, usize)> {
+    (1usize..100).prop_flat_map(move |length| {
         (
             prop::collection::vec(any::<bool>(), length),
             prop::collection::vec(any::<bool>(), length),
             0u8..4,
             0..length,
         )
-            .prop_map(|(mut x_bits, mut z_bits, phase, index)| {
-                x_bits[index] = false;
-                z_bits[index] = false;
+            .prop_map(move |(mut x_bits, mut z_bits, phase, index)| {
+                if let Some(local_x) = local_x {
+                    x_bits[index] = local_x;
+                }
+                if let Some(local_z) = local_z {
+                    z_bits[index] = local_z;
+                }
                 (PauliUnitary::from_bits(x_bits, z_bits, phase), index)
             })
     })


### PR DESCRIPTION
Fix #147 

Use the local $x\oplus z$ condition in `apply_root_y`, matching
anticommutation with $Y$. Add a property test that generates arbitrary
Paulis with a selected identity site and verifies the full Pauli is unchanged.