### PR TITLE
Round-trip zero-qubit Clifford strings

### DIFF
--- a/paulimer/src/clifford/clifford_impl.rs
+++ b/paulimer/src/clifford/clifford_impl.rs
@@ -1169,7 +1169,11 @@ where
     SparsePauliLike: Pauli + std::str::FromStr,
     CliffordLike: Clifford<DensePauli = DensePauliLike>,
 {
-    let trimmed = s.trim().trim_end_matches(',');
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return Ok(CliffordLike::identity(0));
+    }
+    let trimmed = trimmed.trim_end_matches(',');
     let pauli_images = trimmed.split(['\n', ',']);
     let mut image_pairs = Vec::new();
     for pauli_image in pauli_images {

--- a/paulimer/tests/clifford_test.rs
+++ b/paulimer/tests/clifford_test.rs
@@ -97,6 +97,21 @@ fn identity_preimages() {
     }
 }
 
+#[test]
+fn zero_qubit_clifford_string_roundtrip() {
+    let exact = CliffordUnitary::identity(0);
+    assert_eq!(exact.to_string().parse::<CliffordUnitary>().unwrap(), exact);
+
+    let projective = CliffordUnitaryModPauli::identity(0);
+    assert_eq!(
+        projective.to_string().parse::<CliffordUnitaryModPauli>().unwrap(),
+        projective
+    );
+
+    assert!(",,,".parse::<CliffordUnitary>().is_err());
+    assert!(",,,".parse::<CliffordUnitaryModPauli>().is_err());
+}
+
 proptest! {
     #[test]
     fn from_images(clifford in arbitrary_clifford(0..1)) {


### PR DESCRIPTION
Fix #149 

Interpret an empty or whitespace-only Clifford string as the unique
zero-qubit identity while retaining errors for comma-only input. Add exact and
projective display/parse round-trip regressions.