### PR TITLE
Handle empty Clifford permutations

### DIFF
--- a/paulimer/src/clifford/clifford_impl.rs
+++ b/paulimer/src/clifford/clifford_impl.rs
@@ -833,26 +833,13 @@ where
 fn is_permutation(sequence: &[usize]) -> bool {
     let mut seq = sequence.to_vec();
     seq.sort_unstable();
-    if seq[0] != 0 {
-        return false;
-    }
-    for j in 0..seq.len() - 1 {
-        if seq[j] + 1 != seq[j + 1] {
-            return false;
-        }
-    }
-    true
+    seq.into_iter().eq(0..sequence.len())
 }
 
 fn has_no_duplicates(sequence: &[usize]) -> bool {
     let mut seq = sequence.to_vec();
     seq.sort_unstable();
-    for j in 0..seq.len() - 1 {
-        if seq[j] == seq[j + 1] {
-            return false;
-        }
-    }
-    true
+    seq.windows(2).all(|pair| pair[0] != pair[1])
 }
 
 impl CliffordMutable for CliffordUnitaryModPauli {

--- a/paulimer/tests/clifford_test.rs
+++ b/paulimer/tests/clifford_test.rs
@@ -1274,6 +1274,24 @@ fn left_mul_permutation_test() {
     left_mul_permutation_generic_test::<CliffordUnitaryModPauli>();
 }
 
+fn empty_permutation_is_identity_generic<CliffordLike: TestableClifford + Clone>() {
+    let mut empty_clifford = CliffordLike::identity(0);
+    empty_clifford.left_mul_permutation(&[], &[]);
+    assert!(empty_clifford.is_identity());
+
+    let mut clifford = CliffordLike::identity(3);
+    clifford.left_mul_swap(0, 1);
+    let expected = clifford.clone();
+    clifford.left_mul_permutation(&[], &[]);
+    assert_eq!(clifford, expected);
+}
+
+#[test]
+fn empty_permutation_is_identity() {
+    empty_permutation_is_identity_generic::<CliffordUnitary>();
+    empty_permutation_is_identity_generic::<CliffordUnitaryModPauli>();
+}
+
 fn format_string_roundtrip_generic_test<CliffordLike: TestableClifford>(clifford: &CliffordLike) {
     let dense_str = format!("{clifford}");
     let sparse_str = format!("{clifford:#}");


### PR DESCRIPTION
Fix #151 

Express the shared permutation and duplicate checks with iterator equality and
`windows(2)`, which handle empty slices naturally. This also fixes empty
support assertions in `left_mul_clifford`; the regressions cover empty
permutations on zero-qubit and nontrivial exact and projective tableaux.