### PR TITLE
Keep Clifford validation silent

### DIFF
--- a/paulimer/src/clifford/generic_algos.rs
+++ b/paulimer/src/clifford/generic_algos.rs
@@ -91,7 +91,6 @@ pub fn is_valid_clifford<CliffordLike: Clifford + PreimageViews>(candidate: &Cli
         let x_preimage = candidate.preimage_x_view(index);
         let z_preimage = candidate.preimage_z_view(index);
         if commutes_with(&x_preimage, &z_preimage) {
-            println!("commutes_with failed for:{index}");
             return false;
         }
         for other_index in index + 1..candidate.num_qubits() {
@@ -102,7 +101,6 @@ pub fn is_valid_clifford<CliffordLike: Clifford + PreimageViews>(candidate: &Cli
             let zx = anti_commutes_with(&z_preimage, &other_x_preimage);
             let zz = anti_commutes_with(&z_preimage, &other_z_preimage);
             if xx || xz || zx || zz {
-                println!("anti_commutes_with failed for:{index}, {other_index}, {xx} {xz} {zx} {zz}");
                 return false;
             }
         }

--- a/paulimer/tests/clifford_test.rs
+++ b/paulimer/tests/clifford_test.rs
@@ -945,6 +945,36 @@ fn clifford_identity_test() {
     generic_clifford_identity_test::<CliffordUnitary>(max_qubits);
 }
 
+#[test]
+#[ignore = "subprocess helper"]
+fn validate_invalid_cliffords() {
+    assert!(!CliffordUnitary::zero(1).is_valid());
+
+    let mut cross_qubit_failure = CliffordUnitary::identity(2);
+    cross_qubit_failure
+        .preimage_x_view_mut(1)
+        .assign(&"XI".parse::<DensePauli>().unwrap());
+    assert!(!cross_qubit_failure.is_valid());
+}
+
+#[test]
+fn invalid_clifford_validation_is_silent() {
+    let output = std::process::Command::new(std::env::current_exe().unwrap())
+        .args(["--exact", "validate_invalid_cliffords", "--ignored", "--nocapture"])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "child test failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("test validate_invalid_cliffords"));
+    assert!(!stdout.contains("commutes_with failed"));
+    assert!(!String::from_utf8_lossy(&output.stderr).contains("commutes_with failed"));
+}
+
 fn two_qubit_clifford<CliffordLike: TestableClifford>(
     transformation: impl FnOnce(&mut CliffordLike, usize, usize),
 ) -> CliffordLike {


### PR DESCRIPTION
Fix #153

Remove the two unconditional diagnostic prints from Clifford validation. Add a
subprocess regression that verifies an invalid tableau is rejected without
writing diagnostics to standard output or standard error.