### PR TITLE
Compute centralizer abelianness

### DIFF
--- a/paulimer/src/pauli_group.rs
+++ b/paulimer/src/pauli_group.rs
@@ -655,7 +655,7 @@ pub fn centralizer_within(support: &[usize], group: &PauliGroup) -> PauliGroup {
         centralizer_generators.push(complex_phase);
     }
 
-    PauliGroup::with_promise(&centralizer_generators, true)
+    PauliGroup::new(&centralizer_generators)
 }
 
 #[must_use]

--- a/paulimer/tests/pauli_group_test.rs
+++ b/paulimer/tests/pauli_group_test.rs
@@ -1,7 +1,7 @@
 use binar::{Bitwise, BitwiseMut, IndexSet};
 use itertools::Itertools;
 use paulimer::pauli::{Pauli, PauliMutable, SparsePauli, commutes_with};
-use paulimer::pauli_group::{PauliGroup, centralizer_of, symplectic_form_of};
+use paulimer::pauli_group::{PauliGroup, centralizer_of, centralizer_within, symplectic_form_of};
 use paulimer::traits::NeutralElement;
 use proptest::collection::vec;
 use proptest::prelude::*;
@@ -65,6 +65,18 @@ fn small_pauli_group() -> BoxedStrategy<PauliGroup> {
 
 fn pauli_group_pairs() -> BoxedStrategy<(PauliGroup, PauliGroup)> {
     (small_pauli_group(), small_pauli_group()).boxed()
+}
+
+#[test]
+fn centralizer_reports_abelian_property() {
+    let trivial_group = PauliGroup::new(&[]);
+    assert!(!centralizer_within(&[0], &trivial_group).is_abelian());
+
+    let repetition_checks = PauliGroup::from_strings(&["ZZ"]);
+    assert!(!centralizer_within(&[0, 1], &repetition_checks).is_abelian());
+
+    let bell_stabilizers = PauliGroup::from_strings(&["XX", "ZZ"]);
+    assert!(centralizer_within(&[0, 1], &bell_stabilizers).is_abelian());
 }
 
 proptest! {


### PR DESCRIPTION
Fix #155 

Construct centralizers without an abelian promise so `PauliGroup` computes the
property from its generators. Add nonabelian one- and two-qubit regressions and
preserve an abelian Bell-stabilizer centralizer as a positive control. Methods
that depend on `is_abelian()` also stop inheriting the false promise.