### PR TITLE
Include scalar Pauli centralizer phases

### DIFF
--- a/paulimer/src/pauli_group.rs
+++ b/paulimer/src/pauli_group.rs
@@ -650,10 +650,8 @@ pub fn centralizer_within(support: &[usize], group: &PauliGroup) -> PauliGroup {
     let mut centralizer_generators = as_sparse_paulis(&kernel_basis, group.support());
     centralizer_generators.extend(basis_over(support, group.support()));
 
-    if !(group.generators.is_empty() || support.is_empty()) {
-        let complex_phase = SparsePauli::from_bits(IndexSet::new(), IndexSet::new(), 1);
-        centralizer_generators.push(complex_phase);
-    }
+    let complex_phase = SparsePauli::from_bits(IndexSet::new(), IndexSet::new(), 1);
+    centralizer_generators.push(complex_phase);
 
     PauliGroup::with_promise(&centralizer_generators, true)
 }

--- a/paulimer/tests/pauli_group_test.rs
+++ b/paulimer/tests/pauli_group_test.rs
@@ -1,7 +1,7 @@
 use binar::{Bitwise, BitwiseMut, IndexSet};
 use itertools::Itertools;
 use paulimer::pauli::{Pauli, PauliMutable, SparsePauli, commutes_with};
-use paulimer::pauli_group::{PauliGroup, centralizer_of, symplectic_form_of};
+use paulimer::pauli_group::{PauliGroup, centralizer_of, centralizer_within, symplectic_form_of};
 use paulimer::traits::NeutralElement;
 use proptest::collection::vec;
 use proptest::prelude::*;
@@ -68,6 +68,27 @@ fn pauli_group_pairs() -> BoxedStrategy<(PauliGroup, PauliGroup)> {
 }
 
 proptest! {
+    #[test]
+    fn trivial_centralizer_contains_all_scalar_phases(support_size in 0usize..16) {
+        let support = (0..support_size).collect::<Vec<_>>();
+        let centralizer = centralizer_within(&support, &PauliGroup::new(&[]));
+        for phase in 0..4 {
+            let scalar = SparsePauli::from_bits(IndexSet::new(), IndexSet::new(), phase);
+            prop_assert!(centralizer.contains(&scalar));
+        }
+        prop_assert_eq!(centralizer.log2_size(), 2 * support_size + 2);
+    }
+
+    #[test]
+    fn empty_support_centralizer_contains_only_scalar_phases(group in small_pauli_group()) {
+        let centralizer = centralizer_within(&[], &group);
+        for phase in 0..4 {
+            let scalar = SparsePauli::from_bits(IndexSet::new(), IndexSet::new(), phase);
+            prop_assert!(centralizer.contains(&scalar));
+        }
+        prop_assert_eq!(centralizer.log2_size(), 2);
+    }
+
     #[test]
     fn test_generators_match_construction_argument(generators in sparse_paulis(1, 5, small_sparse_pauli())) {
         let group = PauliGroup::new(&generators);


### PR DESCRIPTION
Fix #157 

Always add $iI$ to the centralizer generators; its powers supply all four
scalar phases. Add property tests over support sizes and generated groups that
check the trivial-group and empty-support centralizers, including their exact
orders.