### PR TITLE
Recompute abelianness after Pauli group reduction

### DIFF
--- a/paulimer/src/pauli_group.rs
+++ b/paulimer/src/pauli_group.rs
@@ -422,9 +422,6 @@ impl PauliGroup {
             generator.assign_phase_exp(new_exponent);
         }
 
-        if *self.is_abelian_promise.get().unwrap_or(&false) {
-            return Self::with_promise(&generators, true);
-        }
         Self::new(&generators)
     }
 

--- a/paulimer/tests/pauli_group_test.rs
+++ b/paulimer/tests/pauli_group_test.rs
@@ -1147,6 +1147,21 @@ fn test_remainder_examples() {
     assert_eq!(remainder.log2_size(), 1);
 }
 
+#[test]
+fn modulo_abelianness_is_not_cache_dependent() {
+    let divisor = PauliGroup::from_strings(&["XI"]);
+    let group = PauliGroup::from_strings(&["XZ", "ZX"]);
+
+    let cold_remainder = group.modulo(&divisor);
+    assert!(!cold_remainder.is_abelian());
+    assert_eq!(cold_remainder.log2_size(), 3);
+
+    assert!(group.is_abelian());
+    let warm_remainder = group.modulo(&divisor);
+    assert!(!warm_remainder.is_abelian());
+    assert_eq!(warm_remainder.log2_size(), 3);
+}
+
 proptest! {
     #[test]
     fn test_remainder_coset_equivalence (


### PR DESCRIPTION
Fix #159

Construct the reduced group without propagating the input's cached
abelianness. Add a regression that compares cold- and warm-cache reductions
whose residual generators anticommute.