### PR TITLE
Validate parsed Clifford tableaux without panicking

### DIFF
--- a/paulimer/src/clifford/clifford_impl.rs
+++ b/paulimer/src/clifford/clifford_impl.rs
@@ -1161,13 +1161,10 @@ fn clifford_from_str<DensePauliLike, SparsePauliLike, CliffordLike>(
     s: &str,
 ) -> Result<CliffordLike, CliffordStringParsingError>
 where
-    DensePauliLike: Pauli
-        + NeutralElement<NeutralElementType = DensePauliLike>
-        + Clone
-        + PauliBinaryOps<SparsePauliLike>
-        + fmt::Display,
     SparsePauliLike: Pauli + std::str::FromStr,
-    CliffordLike: Clifford<DensePauli = DensePauliLike>,
+    CliffordLike: Clifford<DensePauli = DensePauliLike>
+        + MutablePreImages<PhaseExponentValue = <CliffordLike as Clifford>::PhaseExponentValue>,
+    for<'life> <CliffordLike as MutablePreImages>::PreImageViewMut<'life>: PauliBinaryOps<SparsePauliLike>,
 {
     let trimmed = s.trim().trim_end_matches(',');
     let pauli_images = trimmed.split(['\n', ',']);
@@ -1188,14 +1185,17 @@ where
     }
     if image_pairs.len() % 2 == 0 {
         let qubit_count = image_pairs.len() / 2;
-        let mut preimages = vec![DensePauliLike::neutral_element_of_size(qubit_count); 2 * qubit_count];
+        let mut clifford = CliffordLike::zero(qubit_count);
         for (pauli_from, pauli_to) in image_pairs {
             if pauli_from.weight() == 1 {
                 if let Some(qubit_id) = pauli_from.support().next() {
+                    if qubit_id >= qubit_count || pauli_to.max_support().is_some_and(|index| index >= qubit_count) {
+                        return Err(CliffordStringParsingError);
+                    }
                     if pauli_from.is_pauli_x(qubit_id) {
-                        preimages[2 * qubit_id].assign(&pauli_to);
+                        clifford.preimage_x_view_mut(qubit_id).assign(&pauli_to);
                     } else if pauli_from.is_pauli_z(qubit_id) {
-                        preimages[2 * qubit_id + 1].assign(&pauli_to);
+                        clifford.preimage_z_view_mut(qubit_id).assign(&pauli_to);
                     } else {
                         return Err(CliffordStringParsingError);
                     }
@@ -1206,7 +1206,6 @@ where
                 return Err(CliffordStringParsingError);
             }
         }
-        let clifford = CliffordLike::from_preimages(&preimages);
         if !clifford.is_valid() {
             return Err(CliffordStringParsingError);
         }

--- a/paulimer/src/clifford/generic_algos.rs
+++ b/paulimer/src/clifford/generic_algos.rs
@@ -90,6 +90,9 @@ pub fn is_valid_clifford<CliffordLike: Clifford + PreimageViews>(candidate: &Cli
     for index in 0..candidate.num_qubits() {
         let x_preimage = candidate.preimage_x_view(index);
         let z_preimage = candidate.preimage_z_view(index);
+        if !x_preimage.is_order_two() || !z_preimage.is_order_two() {
+            return false;
+        }
         if commutes_with(&x_preimage, &z_preimage) {
             println!("commutes_with failed for:{index}");
             return false;

--- a/paulimer/tests/clifford_test.rs
+++ b/paulimer/tests/clifford_test.rs
@@ -97,7 +97,54 @@ fn identity_preimages() {
     }
 }
 
+#[test]
+fn invalid_clifford_string_returns_error() {
+    for invalid in ["Z₀→Z₀, X₀→Z₀", "Z₁→Z₀, X₀→X₀", "Z₀→Z₁, X₀→X₀", "Z₀→Z₀, X₀→X₀X₁"]
+    {
+        assert!(invalid.parse::<CliffordUnitary>().is_err());
+        assert!(invalid.parse::<CliffordUnitaryModPauli>().is_err());
+    }
+}
+
+#[test]
+fn nonhermitian_clifford_string_returns_error() {
+    assert!("X₀→Y₀, Z₀→Z₀".parse::<CliffordUnitary>().is_ok());
+    assert!("X₀→iX₀, Z₀→Z₀".parse::<CliffordUnitary>().is_err());
+    assert!("X₀→iY₀, Z₀→Z₀".parse::<CliffordUnitary>().is_err());
+    assert!("X₀→iX₀, Z₀→Z₀".parse::<CliffordUnitaryModPauli>().is_ok());
+}
+
 proptest! {
+    #[test]
+    fn nonhermitian_preimage_is_invalid(
+        num_qubits in 1usize..32,
+        generator_index in any::<usize>(),
+        use_z_preimage in any::<bool>(),
+        use_minus_i in any::<bool>(),
+    ) {
+        let mut candidate = CliffordUnitary::identity(num_qubits);
+        let generator_index = generator_index % num_qubits;
+        {
+            let (mut x_preimage, mut z_preimage) = candidate.preimage_xz_views_mut(generator_index);
+            if use_z_preimage {
+                z_preimage.add_assign_phase_exp(2);
+            } else {
+                x_preimage.add_assign_phase_exp(2);
+            }
+        }
+        prop_assert!(candidate.is_valid());
+        {
+            let (mut x_preimage, mut z_preimage) = candidate.preimage_xz_views_mut(generator_index);
+            let phase = if use_minus_i { 3 } else { 1 };
+            if use_z_preimage {
+                z_preimage.add_assign_phase_exp(phase);
+            } else {
+                x_preimage.add_assign_phase_exp(phase);
+            }
+        }
+        prop_assert!(!candidate.is_valid());
+    }
+
     #[test]
     fn from_images(clifford in arbitrary_clifford(0..1)) {
         let images = images_of(&clifford);


### PR DESCRIPTION
Require every exact $X/Z$ generator preimage to be order two before running
the existing commutation checks. Assign parsed preimages directly into a
zero-initialized tableau, reject out-of-range indices, validate without the
panicking constructor, and return the existing parse error when invalid.
Add exact-phase property coverage plus regressions for nonsymplectic,
non-Hermitian, out-of-range, and padded strings. Projective phase validation
is unchanged because projective Paulis erase phase. The infallible
`from_preimages` and `from_images` constructors retain their validity
assertions and therefore reject invalid exact inputs by panicking. The
separate maximum-index Pauli parser fix closes the remaining debug-build
overflow before these dimension checks run.