### PR TITLE
Update PyO3 dependencies to 0.29

### DIFF
--- a/binar/Cargo.toml
+++ b/binar/Cargo.toml
@@ -25,7 +25,7 @@ rand = "0.10"
 sorted-vec = "0.8"
 sorted-iter = "0.1"
 derive_more = { version = "2.0.1", features = ["deref", "deref_mut", "display", "error", "from", "into"] }
-pyo3 = { version = "0.27.1", optional = true }
+pyo3 = { version = "0.29", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/binar/bindings/python/Cargo.toml
+++ b/binar/bindings/python/Cargo.toml
@@ -20,13 +20,13 @@ rand = "0.10"
 derive_more = { version = "2.0.1", features = ["deref", "deref_mut", "from", "into"] }
 
 [target.'cfg(not(target_os = "emscripten"))'.dependencies]
-pyo3 = { version = "0.27.1", features = ["extension-module", "abi3-py39"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
-pyo3 = { version = "0.27.1", features = ["extension-module"] }
+pyo3 = { version = "0.29", features = ["extension-module"] }
 
 [build-dependencies]
-pyo3-build-config = "0.27.1"
+pyo3-build-config = "0.29"
 
 [[test]]
 name = "python-bindings"

--- a/deq/deq_runtime/Cargo.toml
+++ b/deq/deq_runtime/Cargo.toml
@@ -73,14 +73,14 @@ serde_json = { version = ">=1.0.138, <1.0.142", features = [
 ] }
 hashbrown = "0.16.0"
 ordered-float = "5.1.0"
-pyo3 = { version = "0.27.1", features = [
+pyo3 = { version = "0.29", features = [
     "multiple-pymethods",
     "abi3-py38",
     "macros",
     "auto-initialize",
     "generate-import-lib",
 ], optional = true }
-pyo3-async-runtimes = { version = "0.27.0", default-features = false, features = [
+pyo3-async-runtimes = { version = "0.29", default-features = false, features = [
     "tokio-runtime",
 ], optional = true }
 clap = { version = "4.5.30", features = ["cargo", "derive"], optional = true }

--- a/deq/deqagram/bindings/python/Cargo.toml
+++ b/deq/deqagram/bindings/python/Cargo.toml
@@ -16,4 +16,4 @@ test = false
 deqagram = { path = "../.." }
 # abi3-py38 + extension-module match deq_runtime, easing eventual co-location in
 # the deq workspace.
-pyo3 = { version = "0.27.1", features = ["abi3-py38", "extension-module"] }
+pyo3 = { version = "0.29", features = ["abi3-py38", "extension-module"] }

--- a/deq/deqagram/bindings/python/tests/test_wrapper.py
+++ b/deq/deqagram/bindings/python/tests/test_wrapper.py
@@ -43,9 +43,9 @@ def test_deqfile_shape() -> None:
     assert f.imports == ["other.deq"]
     kinds = [type(d).__qualname__ for d in f.definitions]
     assert kinds == [
-        "Definition_Code",
-        "Definition_Gadget",
-        "Definition_Program",
+        "Definition.Code",
+        "Definition.Gadget",
+        "Definition.Program",
     ]
 
 

--- a/paulimer/Cargo.toml
+++ b/paulimer/Cargo.toml
@@ -20,7 +20,7 @@ once_cell = "1.21.3"
 itertools = "0.14"
 num-derive = "0.4.2"
 num-traits = "0.2.19"
-pyo3 = { version = "0.27.1", optional = true }
+pyo3 = { version = "0.29", optional = true }
 derive_more = { version = "2.0.1", features = [
     "deref",
     "deref_mut",

--- a/paulimer/bindings/python/Cargo.toml
+++ b/paulimer/bindings/python/Cargo.toml
@@ -26,13 +26,13 @@ derive_more = { version = "2.0.1", features = [
 ] }
 
 [target.'cfg(not(target_os = "emscripten"))'.dependencies]
-pyo3 = { version = "0.27.1", features = ["extension-module", "abi3-py39"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py39"] }
 
 [target.'cfg(target_os = "emscripten")'.dependencies]
-pyo3 = { version = "0.27.1", features = ["extension-module"] }
+pyo3 = { version = "0.29", features = ["extension-module"] }
 
 [build-dependencies]
-pyo3-build-config = "0.27.1"
+pyo3-build-config = "0.29"
 
 [[test]]
 name = "paulimer-python-bindings"


### PR DESCRIPTION
## Summary

- update PyO3 and related crates to 0.29
- resolve five vulnerabilities reported by `cargo audit`
- allow fresh resolution to select patched `crossbeam-epoch`, `h2`, and `rtrb` releases

## Validation

- `cargo audit` reports 0 vulnerabilities and 9 allowed upstream warnings
- `cargo check --workspace --all-features --lib --bins --benches`
- applicable workspace tests pass